### PR TITLE
Adding some useful methods when working with segments

### DIFF
--- a/tests/ida_domain_test.py
+++ b/tests/ida_domain_test.py
@@ -136,7 +136,12 @@ def test_database(test_env):
 def test_segment(test_env):
     db = test_env
 
-    assert len(db.segments) == 4
+    seg = db.segments.add_new_last(0, 0x100, ".ifak", "CODE", 0)
+    assert seg is not None
+    assert db.segments.set_segment_rwx(seg) == True
+    assert db.segments.set_segment_addr_mode(seg, 64) == True
+
+    assert len(db.segments) == 5
     for segment in db.segments:
         assert db.segments.get_name(segment)
 


### PR DESCRIPTION
Hello Dear Hex-Rays Team!

During daily research work at the company, I noticed that the project did not have methods to manipulate new segments.
Therefore, I created some methods in a more pythonic way for this purpose.

**New methods in the Segments class:**

1. **add_new** – Adds a new segment based on a provided start_ea.
2. **add_new_last** – A wrapper for add_new, with the difference that it obtains the last segment and uses its end_ea to calculate the next one (the only task for the user being to provide the segment size).
3. **set_segment_rwx** – Configures a given segment with RWX permission (this can certainly be expanded to allow other types of configurations).
4. **set_segment_addr_mode** – Configures the addressing mode of a given segment in a pythonic way.
	
**Usage Demo:**
<img width="517" height="97" alt="image" src="https://github.com/user-attachments/assets/bb665810-bc39-4c80-9747-98b0b27d3876" />

**Result:**
<img width="857" height="17" alt="image" src="https://github.com/user-attachments/assets/074004e0-ad33-443b-ac04-bd0e7cc4bd29" />

Tests were previously added to the test file to demonstrate usage (done in a basic way, improvements can surely be made).

Thanks for ida-domain, I hope my contribution adds value to the project!