### PR TITLE
fix(idapro): raise clear error when IDADIR is not set

### DIFF
--- a/ida_domain/__init__.py
+++ b/ida_domain/__init__.py
@@ -22,7 +22,13 @@ def _load_dependencies() -> None:
         need_idapro = True
 
     if need_idapro:
-        import idapro
+        try:
+            import idapro
+        except OSError as e:
+            raise RuntimeError(
+                'Failed to load idapro module. Make sure IDA is properly installed and '
+                'the IDADIR environment variable is set correctly.'
+            ) from e
 
 
 __version__ = '0.1.0'


### PR DESCRIPTION
When the IDADIR is not Set , the script will report an error and terminate, but no clear error message is given
like this
<img width="981" height="271" alt="image" src="https://github.com/user-attachments/assets/11c6497a-d7b8-4314-afd5-ea9030d6989e" />

After add some code,it will tell you the reason
 
<img width="1105" height="457" alt="image" src="https://github.com/user-attachments/assets/b3800dde-5b76-41b1-91f6-20b84c97debf" />
