### PR TITLE
functions: fix get_instructions type hint

### DIFF
--- a/ida_domain/functions.py
+++ b/ida_domain/functions.py
@@ -649,7 +649,7 @@ class Functions(DatabaseEntity):
         """
         return ida_domain.flowchart.FlowChart(self.database, func, None, flags)
 
-    def get_instructions(self, func: func_t) -> Optional[Iterator[insn_t]]:
+    def get_instructions(self, func: func_t) -> Iterator[insn_t]:
         """
         Retrieves all instructions within the given function.
 


### PR DESCRIPTION
Updated the return type of get_instructions to remove Optional.


There are probably other places that need to be fixed, so I'll leave this in a draft state for the moment.