### PR TITLE
Include docs and examples in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,15 @@ Repository = "https://github.com/hexrayssa/ida-domain"
 Issues = "https://github.com/hexrayssa/ida-domain/issues"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ida_domain"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"docs" = "ida_domain/_docs"
+"examples" = "ida_domain/_examples"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This allows downstream consumers to inspect the docs/examples with

```
importlib.resources.files("ida_domain") / "_docs"
```

Had to switch to hatchling, but everything should work exactly the same.