### PR TITLE
Refactor lvar reference analysis and expose ctree context #80

### DIFF
--- a/ida_domain/functions.py
+++ b/ida_domain/functions.py
@@ -3,17 +3,15 @@ from __future__ import annotations
 import logging
 import warnings
 from dataclasses import dataclass
-from enum import Enum, Flag, IntEnum
+from enum import Flag
 
 import ida_bytes
 import ida_funcs
-import ida_hexrays
 import ida_lines
 import ida_name
 import ida_typeinf
 from ida_funcs import func_t
 from ida_idaapi import BADADDR, ea_t
-from ida_typeinf import tinfo_t
 from ida_ua import insn_t
 from typing_extensions import TYPE_CHECKING, Any, Iterator, List, Optional
 
@@ -30,49 +28,19 @@ from .base import (
     decorate_all_methods,
 )
 from .flowchart import FlowChart, FlowChartFlags
+from .pseudocode import (
+    LocalVariable,
+    LocalVariableAccessType,
+    LocalVariableContext,
+    LocalVariableReference,
+    PseudocodeFunction,
+)
 
 if TYPE_CHECKING:
     from .database import Database
     from .microcode import MicroBlockArray
-    from .pseudocode import PseudocodeFunction
 
 logger = logging.getLogger(__name__)
-
-
-class LocalVariableAccessType(IntEnum):
-    """Type of access to a local variable."""
-
-    READ = 1
-    """Variable value is read"""
-    WRITE = 2
-    """Variable value is modified"""
-    ADDRESS = 3
-    """Address of variable is taken (&var)"""
-
-
-class LocalVariableContext(Enum):
-    """Context where local variable is referenced."""
-
-    ASSIGNMENT = 'assignment'
-    """var = expr or expr = var"""
-    CONDITION = 'condition'
-    """if (var), while (var), etc."""
-    CALL_ARG = 'call_arg'
-    """func(var)"""
-    RETURN = 'return'
-    """return var"""
-    ARITHMETIC = 'arithmetic'
-    """var + 1, var * 2, etc."""
-    COMPARISON = 'comparison'
-    """var == x, var < y, etc."""
-    ARRAY_INDEX = 'array_index'
-    """arr[var] or var[i]"""
-    POINTER_DEREF = 'pointer_deref'
-    """*var or var->field"""
-    CAST = 'cast'
-    """(type)var"""
-    OTHER = 'other'
-    """Other contexts"""
 
 
 class FunctionFlags(Flag):
@@ -121,45 +89,6 @@ class FunctionFlags(Flag):
 
 
 @dataclass
-class LocalVariable:
-    """Represents a local variable or argument in a function."""
-
-    index: int
-    """Variable index in function"""
-    name: str
-    """Variable name"""
-    type: Optional[tinfo_t]
-    """Type information"""
-    size: int
-    """Size in bytes"""
-    is_argument: bool
-    """True if is a function argument"""
-    is_result: bool
-    """True if is a return value variable"""
-
-    @property
-    def type_str(self) -> str:
-        """Get string representation of the type."""
-        return str(self.type) if self.type else ''
-
-
-@dataclass
-class LocalVariableReference:
-    """Reference to a local variable in pseudocode."""
-
-    access_type: LocalVariableAccessType
-    """How variable is accessed"""
-    context: Optional[LocalVariableContext] = None
-    """Usage context"""
-    ea: Optional[ea_t] = None
-    """Binary address if mappable"""
-    line_number: Optional[int] = None
-    """Line number in pseudocode"""
-    code_line: Optional[str] = None
-    """The pseudocode line containing the reference"""
-
-
-@dataclass
 class StackPoint:
     """Stack pointer change information."""
 
@@ -189,338 +118,6 @@ class FunctionChunk:
     """End address of the function chunk"""
     is_main: bool
     """True if is the function main chunk"""
-
-
-# ============================================================================
-# Ctree Assignment Detection
-# ============================================================================
-#
-# The hexrays ctree represents decompiled code as nested expression trees.
-# Determining write access requires analyzing the tree structure.
-#
-# Direct assignment: v9 = 10
-#
-#   cot_asg
-#   ├── x: cot_var (v9)     ← variable is direct child of assignment
-#   └── y: cot_num (10)
-#
-# Nested assignment: HIWORD(v9) = a1  (helper function wrapping variable)
-#
-#   cot_asg
-#   ├── x: cot_helper (HIWORD)
-#   │       └── a[0]: cot_var (v9)   ← variable is nested in left subtree
-#   └── y: cot_var (a1)
-#
-# Other nested patterns include casts, pointer dereferences, and array indexing:
-#   *ptr = x        →  cot_ptr wraps the variable
-#   arr[i] = x      →  cot_idx wraps the variable
-#   (cast)v = x     →  cot_cast wraps the variable
-#
-# Problem:
-#   A direct parent check (parent.op == cot_asg and parent.x == expr) only
-#   handles direct assignments. In nested cases, the variable's immediate
-#   parent is the wrapper expression (helper/cast/ptr), not the assignment.
-#
-# Solution:
-#   Two-direction traversal:
-#   1. UP: Traverse ancestor chain to locate an assignment operator
-#   2. DOWN: Verify the variable resides in the assignment's left subtree
-#
-# Without this logic, `HIWORD(v9) = a1` incorrectly reports `v9` as READ
-# because the immediate parent is cot_helper. This affects data flow analysis
-# and variable access classification.
-#
-# Performance characteristics:
-#   - Up-traversal: O(d) where d = ancestor depth, typically 1-5 levels
-#   - Down-traversal: O(n) where n = nodes in left subtree, typically 1-10
-#   - Invoked once per variable reference during ctree visitor traversal
-#
-# ============================================================================
-
-# All assignment operators in IDA hexrays ctree
-_ASSIGNMENT_OPS = (
-    ida_hexrays.cot_asg,
-    ida_hexrays.cot_asgadd,
-    ida_hexrays.cot_asgmul,
-    ida_hexrays.cot_asgsub,
-    ida_hexrays.cot_asgsdiv,
-    ida_hexrays.cot_asgudiv,
-    ida_hexrays.cot_asgsmod,
-    ida_hexrays.cot_asgumod,
-    ida_hexrays.cot_asgbor,
-    ida_hexrays.cot_asgxor,
-    ida_hexrays.cot_asgband,
-    ida_hexrays.cot_asgsshr,
-    ida_hexrays.cot_asgushr,
-    ida_hexrays.cot_asgshl,
-)
-
-
-class _LVarRefsVisitor(ida_hexrays.ctree_parentee_t):
-    """Visitor to find references to a specific local variable in pseudocode.
-
-    Uses ctree_parentee_t which properly maintains parent information.
-    """
-
-    def __init__(self, cfunc: Any, lvar_index: int):
-        super().__init__()
-        self.cfunc = cfunc
-        self.lvar_index = lvar_index
-        self.refs: List[LocalVariableReference] = []
-
-    def visit_expr(self, expr: Any) -> int:
-        """Visit expression nodes to find variable references."""
-        if expr.op == ida_hexrays.cot_var:
-            # Found any variable - check if it's our target
-            if expr.v.idx == self.lvar_index:
-                # Found a reference to our variable
-                # Use parent_expr() to get the parent expression
-                parent = self.parent_expr()
-
-                access_type = self._determine_access_type(expr, parent)
-                context = self._determine_context(expr, parent)
-                ea = expr.ea if expr.ea != BADADDR else None
-
-                # Extract line information
-                line_number = None
-                code_line = None
-
-                # Get line coordinates from the expression
-                coords = self.cfunc.find_item_coords(expr)
-                if coords and len(coords) >= 2:
-                    line_number = coords[1]  # y coordinate is line number
-
-                    # Get the actual pseudocode line
-                    sv = self.cfunc.get_pseudocode()
-                    if 0 <= line_number < len(sv):
-                        code_line = sv[line_number].line
-                        # Remove IDA color/formatting tags
-                        code_line = ida_lines.tag_remove(code_line).strip()
-
-                ref = LocalVariableReference(
-                    access_type=access_type,
-                    context=context,
-                    ea=ea,
-                    line_number=line_number,
-                    code_line=code_line,
-                )
-                self.refs.append(ref)
-        return 0
-
-    def _is_on_left_side_of_assignment(self, asg_expr: Any, child_expr: Any) -> bool:
-        """Check if child_expr is in the left subtree of an assignment.
-
-        Performs a depth-first traversal from the assignment's left operand (.x)
-        to determine if child_expr is reachable. If reachable, the variable is
-        on the write side of the assignment.
-
-        This handles nested patterns where the variable is wrapped in expressions:
-            HIWORD(v9) = a1  →  v9 is inside cot_helper, which is in .x
-            *ptr = val       →  ptr is inside cot_ptr, which is in .x
-
-        Args:
-            asg_expr: An assignment expression (cot_asg or compound assignment).
-            child_expr: The expression to search for in the left subtree.
-
-        Returns:
-            True if child_expr is found in the left subtree (write side).
-
-        Performance:
-            O(n) where n = number of nodes in left subtree. Typically 1-10 nodes
-            for common patterns like helpers, casts, or pointer dereferences.
-        """
-        # asg_expr might be a citem_t, we need to access the cexpr_t
-        # Check if it's an expression type with x attribute
-        if not hasattr(asg_expr, 'x'):
-            # Try to get the expression from citem_t
-            if hasattr(asg_expr, 'cexpr'):
-                asg_expr = asg_expr.cexpr
-            else:
-                return False
-
-        # Get the left side of the assignment
-        left = asg_expr.x
-        if left is None:
-            return False
-
-        # Use a simple BFS/DFS to find if child_expr is in the left subtree
-        stack = [left]
-        while stack:
-            current = stack.pop()
-            if current is None:
-                continue
-            # Check if this is our target expression (by object identity or ea)
-            if current == child_expr:
-                return True
-            if hasattr(current, 'ea') and hasattr(child_expr, 'ea'):
-                if current.ea == child_expr.ea and current.op == child_expr.op:
-                    return True
-            # Traverse children based on expression type
-            if hasattr(current, 'x') and current.x is not None:
-                stack.append(current.x)
-            if hasattr(current, 'y') and current.y is not None:
-                stack.append(current.y)
-            if hasattr(current, 'z') and current.z is not None:
-                stack.append(current.z)
-        return False
-
-    def _find_assignment_in_ancestors(self) -> tuple:
-        """Find an assignment operator in the ancestor chain.
-
-        Traverses from the immediate parent upward through the ancestor chain
-        to locate an assignment operator. When found, determines whether the
-        current expression is on the left (write) or right (read) side.
-
-        This enables correct access type detection for nested patterns:
-            HIWORD(v9) = a1  →  parent of v9 is cot_helper, not assignment
-                             →  ancestor traversal finds the cot_asg above
-
-        Uses self.parents vector maintained by ctree_parentee_t during traversal.
-
-        Returns:
-            Tuple of (assignment_expr, is_on_left_side):
-                - (expr, True) if in left subtree (write side)
-                - (expr, False) if in right subtree (read side)
-                - (None, False) if no assignment found in ancestors
-
-        Performance:
-            O(d) where d = ancestor depth. Typically 1-5 levels for common
-            patterns. The parents vector is already maintained by the base
-            class during tree traversal.
-        """
-        num_parents = len(self.parents)
-        for i in range(num_parents):
-            # Access parents from end (nearest) to beginning (farthest)
-            parent_item = self.parents[num_parents - 1 - i]
-            if parent_item is None:
-                continue
-            # Check if this parent is an expression with an assignment op
-            if not hasattr(parent_item, 'op'):
-                continue
-            if parent_item.op in _ASSIGNMENT_OPS:
-                # Found an assignment - determine if we're on the left side
-                # The item right before this assignment in the parent chain
-                # is the child that leads to our expression
-                if i == 0:
-                    # Immediate parent is assignment, use parent_expr()
-                    child = self.parent_expr()
-                else:
-                    # Get the item that is child of this assignment
-                    child = self.parents[num_parents - i]
-                is_left = self._is_on_left_side_of_assignment(parent_item, child)
-                return (parent_item, is_left)
-        return (None, False)
-
-    def _determine_access_type(self, expr: Any, parent: Any) -> LocalVariableAccessType:
-        """Determine how the variable is being accessed."""
-        if not parent:
-            return LocalVariableAccessType.READ
-
-        # Check if this is a write operation (left side of assignment)
-        if parent.op == ida_hexrays.cot_asg and parent.x == expr:
-            return LocalVariableAccessType.WRITE
-        # Check compound assignments at immediate parent level
-        elif parent.op in _ASSIGNMENT_OPS and parent.x == expr:
-            return LocalVariableAccessType.WRITE
-        # Check if address is taken - but also check ancestors for assignment
-        elif parent.op == ida_hexrays.cot_ref:
-            # Address is taken - check if this is part of an assignment
-            asg, is_left = self._find_assignment_in_ancestors()
-            if asg and is_left:
-                return LocalVariableAccessType.WRITE
-            return LocalVariableAccessType.ADDRESS
-
-        # For calls (including helpers like HIWORD), casts, ptr derefs - check ancestors
-        if parent.op in (
-            ida_hexrays.cot_call,
-            ida_hexrays.cot_helper,
-            ida_hexrays.cot_cast,
-            ida_hexrays.cot_ptr,
-            ida_hexrays.cot_memptr,
-            ida_hexrays.cot_memref,
-            ida_hexrays.cot_add,
-            ida_hexrays.cot_idx,
-        ):
-            asg, is_left = self._find_assignment_in_ancestors()
-            if asg and is_left:
-                return LocalVariableAccessType.WRITE
-
-        return LocalVariableAccessType.READ
-
-    def _determine_context(self, expr: Any, parent: Any) -> LocalVariableContext:
-        """Determine the context where the variable is used."""
-        if not parent:
-            return LocalVariableContext.OTHER
-
-        if parent.op == ida_hexrays.cot_asg:
-            return LocalVariableContext.ASSIGNMENT
-        elif parent.op in _ASSIGNMENT_OPS:
-            return LocalVariableContext.ASSIGNMENT
-        elif parent.op == ida_hexrays.cot_call:
-            # Check if there's an assignment ancestor - if so, this is ASSIGNMENT context
-            asg, is_left = self._find_assignment_in_ancestors()
-            if asg and is_left:
-                return LocalVariableContext.ASSIGNMENT
-            return LocalVariableContext.CALL_ARG
-        elif parent.op in (
-            ida_hexrays.cot_eq,
-            ida_hexrays.cot_ne,
-            ida_hexrays.cot_sge,
-            ida_hexrays.cot_uge,
-            ida_hexrays.cot_sle,
-            ida_hexrays.cot_ule,
-            ida_hexrays.cot_sgt,
-            ida_hexrays.cot_ugt,
-            ida_hexrays.cot_slt,
-            ida_hexrays.cot_ult,
-        ):
-            return LocalVariableContext.COMPARISON
-        elif parent.op in (
-            ida_hexrays.cot_add,
-            ida_hexrays.cot_sub,
-            ida_hexrays.cot_mul,
-            ida_hexrays.cot_sdiv,
-            ida_hexrays.cot_udiv,
-            ida_hexrays.cot_smod,
-            ida_hexrays.cot_umod,
-        ):
-            # Check if there's an assignment ancestor
-            asg, is_left = self._find_assignment_in_ancestors()
-            if asg and is_left:
-                return LocalVariableContext.ASSIGNMENT
-            return LocalVariableContext.ARITHMETIC
-        elif parent.op == ida_hexrays.cot_idx:
-            # Check if there's an assignment ancestor
-            asg, is_left = self._find_assignment_in_ancestors()
-            if asg and is_left:
-                return LocalVariableContext.ASSIGNMENT
-            return LocalVariableContext.ARRAY_INDEX
-        elif parent.op in (ida_hexrays.cot_ptr, ida_hexrays.cot_memptr, ida_hexrays.cot_memref):
-            # Check if there's an assignment ancestor
-            asg, is_left = self._find_assignment_in_ancestors()
-            if asg and is_left:
-                return LocalVariableContext.ASSIGNMENT
-            return LocalVariableContext.POINTER_DEREF
-        elif parent.op == ida_hexrays.cot_cast:
-            # Check if there's an assignment ancestor
-            asg, is_left = self._find_assignment_in_ancestors()
-            if asg and is_left:
-                return LocalVariableContext.ASSIGNMENT
-            return LocalVariableContext.CAST
-        elif parent.op == ida_hexrays.cot_ref:
-            # Address taken - check for assignment ancestor
-            asg, is_left = self._find_assignment_in_ancestors()
-            if asg and is_left:
-                return LocalVariableContext.ASSIGNMENT
-            return LocalVariableContext.OTHER
-        elif parent.op == ida_hexrays.cot_helper:
-            # Helper functions like HIWORD - check for assignment ancestor
-            asg, is_left = self._find_assignment_in_ancestors()
-            if asg and is_left:
-                return LocalVariableContext.ASSIGNMENT
-            return LocalVariableContext.OTHER
-
-        return LocalVariableContext.OTHER
 
 
 @decorate_all_methods(check_db_open)
@@ -1122,6 +719,9 @@ class Functions(DatabaseEntity):
         """
         Get all local variables for a function.
 
+        Delegates to ``db.pseudocode.decompile()`` and reads the cfunc's
+        lvar table.
+
         Args:
             func: The function instance.
 
@@ -1129,36 +729,24 @@ class Functions(DatabaseEntity):
             List of local variables including arguments and local vars.
 
         Raises:
-            DecompilerError: If decompilation fails for the function.
+            PseudocodeError: If decompilation fails for the function.
         """
-        cfunc = ida_hexrays.decompile(func.start_ea)
-        if not cfunc:
-            raise DecompilerError(f'Failed to decompile function at 0x{func.start_ea:x}')
-
-        lvars = []
-        for i in range(cfunc.lvars.size()):
-            lvar = cfunc.lvars[i]
-
-            # Get type information
-            type_info = lvar.tif
-
-            local_var = LocalVariable(
-                index=i,
-                name=lvar.name,
-                type=type_info,
-                size=lvar.width,
-                is_argument=lvar.is_arg_var,
-                is_result=lvar.is_result_var,
-            )
-            lvars.append(local_var)
-
-        return lvars
+        pcfunc = self.database.pseudocode.decompile(func)
+        raw_cfunc = pcfunc.raw_cfunc
+        return [LocalVariable._from_raw(raw_cfunc, i) for i in range(raw_cfunc.lvars.size())]
 
     def get_local_variable_references(
         self, func: func_t, lvar: LocalVariable
     ) -> List[LocalVariableReference]:
         """
         Get all references to a specific local variable.
+
+        Convenience entry point that forwards to
+        :meth:`PseudocodeFunction.find_variable_references`. Each returned
+        :class:`LocalVariableReference` carries the wrapped ctree nodes
+        (``expr``, ``parent``, lazy ``assignment``, ``walk_ancestors``) so
+        callers can perform deeper analyses — taint tracking, type
+        inference, deobfuscation — without copying any visitor internals.
 
         Args:
             func: The function instance.
@@ -1168,19 +756,11 @@ class Functions(DatabaseEntity):
             List of references to the variable in pseudocode.
 
         Raises:
-            DecompilerError: If decompilation fails for the function.
+            PseudocodeError: If decompilation fails for the function.
         """
-        cfunc = ida_hexrays.decompile(func.start_ea)
-        if not cfunc:
-            raise DecompilerError(f'Failed to decompile function at 0x{func.start_ea:x}')
-
-        # Create visitor to find variable references
-        visitor = _LVarRefsVisitor(cfunc, lvar.index)
-
-        # Visit the function body to find references
-        visitor.apply_to(cfunc.body, None)
-
-        return visitor.refs
+        return self.database.pseudocode.decompile(func).find_variable_references(
+            var_index=lvar.index,
+        )
 
     def get_local_variable_by_name(self, func: func_t, name: str) -> Optional[LocalVariable]:
         """
@@ -1194,7 +774,7 @@ class Functions(DatabaseEntity):
             LocalVariable if found
 
         Raises:
-            DecompilerError: If decompilation fails for the function.
+            PseudocodeError: If decompilation fails for the function.
             KeyError: If the variable is not found
         """
         lvars = self.get_local_variables(func)

--- a/ida_domain/pseudocode.py
+++ b/ida_domain/pseudocode.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from enum import IntEnum, IntFlag
+from dataclasses import dataclass
+from enum import Enum, IntEnum, IntFlag
 
 import ida_hexrays
 import ida_idaapi
@@ -2385,6 +2386,22 @@ class PseudocodeFunction:
             return PseudocodeExpression(raw.cexpr, self)
         return PseudocodeInstruction(raw.cinsn, self)
 
+    def walk_ancestors_of(
+        self,
+        item: PseudocodeExpression,
+    ) -> Iterator[PseudocodeExpression]:
+        """Yield ancestor expressions of ``item`` from innermost to outermost.
+
+        Walks lazily via :meth:`find_parent_of`, so callers that look for
+        one specific ancestor pay only for the depth they actually visit.
+        Stops at the first non-expression ancestor (a statement-level
+        ``cinsn_t`` like a return or if-statement).
+        """
+        cur = self.find_parent_of(item)
+        while isinstance(cur, PseudocodeExpression):
+            yield cur
+            cur = self.find_parent_of(cur)
+
     # -- convenience finders -----------------------------------------------
 
     def find_expression(
@@ -2547,6 +2564,57 @@ class PseudocodeFunction:
             results.append(expr)
         return results
 
+    def find_variable_references(
+        self,
+        var_index: Optional[int] = None,
+        var_name: Optional[str] = None,
+    ) -> List[LocalVariableReference]:
+        """Find all references to a local variable, with access classification.
+
+        Like :meth:`find_variables`, but each returned object is a
+        :class:`LocalVariableReference` that classifies the access
+        (read/write/address-taken), tags the usage context, and exposes the
+        surrounding ctree nodes (``parent``, lazy ``assignment``,
+        ``walk_ancestors()``) for deeper analyses like taint tracking or
+        type inference.
+
+        Args:
+            var_index: If provided, restrict to references of this variable index.
+            var_name: If provided, restrict to references of this variable name.
+
+        Returns:
+            List of classified references in walk order.
+        """
+        refs: List[LocalVariableReference] = []
+        for expr in self.find_variables(var_index=var_index, var_name=var_name):
+            parent_item = self.find_parent_of(expr)
+            parent = parent_item if isinstance(parent_item, PseudocodeExpression) else None
+
+            access_type = _classify_lvar_access(self, expr, parent)
+            context = _classify_lvar_context(self, expr, parent)
+            ea = expr.ea if expr.ea != ida_idaapi.BADADDR else None
+
+            line_number: Optional[int] = None
+            code_line: Optional[str] = None
+            coords = self._raw.find_item_coords(expr.raw_expr)
+            if coords and len(coords) >= 2:
+                line_number = coords[1]
+                sv = self._raw.get_pseudocode()
+                if 0 <= line_number < len(sv):
+                    code_line = ida_lines.tag_remove(sv[line_number].line).strip()
+
+            refs.append(LocalVariableReference(
+                access_type=access_type,
+                context=context,
+                ea=ea,
+                line_number=line_number,
+                code_line=code_line,
+                expr=expr,
+                parent=parent,
+                cfunc=self,
+            ))
+        return refs
+
     def find_objects(self, obj_ea: Optional[int] = None) -> List[PseudocodeExpression]:
         """Find all object reference expressions, optionally filtered by address.
 
@@ -2616,6 +2684,388 @@ class PseudocodeFunction:
             f'PseudocodeFunction(ea=0x{self._raw.entry_ea:x}, '
             f'maturity={self.maturity.name})'
         )
+
+
+# ============================================================================
+# Ctree Assignment Detection
+# ============================================================================
+#
+# The hexrays ctree represents decompiled code as nested expression trees.
+# Determining write access requires analyzing the tree structure.
+#
+# Direct assignment: v9 = 10
+#
+#   cot_asg
+#   ├── x: cot_var (v9)     ← variable is direct child of assignment
+#   └── y: cot_num (10)
+#
+# Nested assignment: HIWORD(v9) = a1  (helper rendered as a call)
+#
+#   cot_asg
+#   ├── x: cot_call
+#   │       ├── x: cot_helper (HIWORD)
+#   │       └── a[0]: cot_var (v9)   ← variable lives in cot_call.a, not in cot_helper
+#   └── y: cot_var (a1)
+#
+# Other nested patterns include casts, pointer dereferences, and array indexing:
+#   *ptr = x        →  cot_ptr wraps the variable
+#   arr[i] = x      →  cot_idx wraps the variable
+#   (cast)v = x     →  cot_cast wraps the variable
+#
+# Problem:
+#   A direct parent check (parent.op == cot_asg and parent.x == expr) only
+#   handles direct assignments. In nested cases, the variable's immediate
+#   parent is the wrapper expression (helper/cast/ptr), not the assignment.
+#
+# Solution:
+#   Walk UP from the variable via ``cfunc.find_parent_of`` repeatedly,
+#   stopping at the first ancestor that is an assignment. The direction
+#   we arrived from (``asg.x`` vs ``asg.y``) tells us which subtree
+#   contains the variable, so a single walk does double duty.
+#
+#   Walking up is preferred over walking DOWN through the assignment's
+#   left subtree because ``find_parent_of`` already understands every
+#   ctree storage slot (``.x/.y/.z`` plus call-argument vectors), so we
+#   don't have to enumerate them manually — important for cases like
+#   ``BYTE8(v) += …`` where the variable hides inside ``cot_call.a``.
+#
+# Without this logic, `HIWORD(v9) = a1` incorrectly reports `v9` as READ
+# because the immediate parent is cot_helper. This affects data flow
+# analysis and variable access classification.
+#
+# Performance characteristics:
+#   - Walk-up: O(d) where d = ancestor depth, typically 1-5 levels
+#   - Invoked once per variable reference during classification
+#
+# ============================================================================
+
+
+class LocalVariableAccessType(IntEnum):
+    """Type of access to a local variable."""
+
+    READ = 1
+    """Variable value is read"""
+    WRITE = 2
+    """Variable value is modified"""
+    ADDRESS = 3
+    """Address of variable is taken (&var)"""
+
+
+class LocalVariableContext(Enum):
+    """Context where a local variable is referenced."""
+
+    ASSIGNMENT = 'assignment'
+    """var = expr or expr = var"""
+    CONDITION = 'condition'
+    """if (var), while (var), etc."""
+    CALL_ARG = 'call_arg'
+    """func(var)"""
+    RETURN = 'return'
+    """return var"""
+    ARITHMETIC = 'arithmetic'
+    """var + 1, var * 2, etc."""
+    COMPARISON = 'comparison'
+    """var == x, var < y, etc."""
+    ARRAY_INDEX = 'array_index'
+    """arr[var] or var[i]"""
+    POINTER_DEREF = 'pointer_deref'
+    """*var or var->field"""
+    CAST = 'cast'
+    """(type)var"""
+    OTHER = 'other'
+    """Other contexts"""
+
+
+@dataclass
+class LocalVariable:
+    """Represents a local variable or argument in a function."""
+
+    index: int
+    """Variable index in function"""
+    name: str
+    """Variable name"""
+    type: Optional[tinfo_t]
+    """Type information"""
+    size: int
+    """Size in bytes"""
+    is_argument: bool
+    """True if is a function argument"""
+    is_result: bool
+    """True if is a return value variable"""
+
+    @property
+    def type_str(self) -> str:
+        """Get string representation of the type."""
+        return str(self.type) if self.type else ''
+
+    @classmethod
+    def _from_raw(cls, raw_cfunc: Any, idx: int) -> LocalVariable:
+        """Build a LocalVariable from a raw cfunc and lvar index."""
+        raw = raw_cfunc.lvars[idx]
+        return cls(
+            index=idx,
+            name=raw.name,
+            type=raw.tif,
+            size=raw.width,
+            is_argument=raw.is_arg_var,
+            is_result=raw.is_result_var,
+        )
+
+
+@dataclass
+class LocalVariableReference:
+    """Reference to a local variable in pseudocode."""
+
+    access_type: LocalVariableAccessType
+    """How variable is accessed"""
+    context: Optional[LocalVariableContext] = None
+    """Usage context"""
+    ea: Optional[ea_t] = None
+    """Binary address if mappable"""
+    line_number: Optional[int] = None
+    """Line number in pseudocode"""
+    code_line: Optional[str] = None
+    """The pseudocode line containing the reference"""
+    expr: Optional[PseudocodeExpression] = None
+    """Wrapped ``cot_var`` expression at this reference site."""
+    parent: Optional[PseudocodeExpression] = None
+    """Immediate parent expression in the ctree, if any."""
+    cfunc: Optional[PseudocodeFunction] = None
+    """Owning decompiled function. Kept on the reference so the wrapped
+    ctree nodes above stay valid for the lifetime of this object."""
+
+    @property
+    def assignment(self) -> Optional[PseudocodeExpression]:
+        """Nearest enclosing assignment expression (``cot_asg`` or compound
+        assignment), if any. Set for both read and write references — for a
+        read, this is the assignment the read participates in (e.g. on the
+        RHS); for a write, this is the assignment that performs the write.
+        """
+        for anc in self.walk_ancestors():
+            if anc.is_assignment:
+                return anc
+        return None
+
+    @property
+    def assignment_rhs(self) -> Optional[PseudocodeExpression]:
+        """Right-hand side of the enclosing assignment, if this reference
+        is on the left side of one.
+
+        Useful for taint propagation and value tracking: when this lvar is
+        being written, ``assignment_rhs`` is the expression whose value it
+        receives.
+        """
+        if self.assignment is None:
+            return None
+        if self.access_type != LocalVariableAccessType.WRITE:
+            return None
+        return self.assignment.y
+
+    @property
+    def assignment_rhs_lvar(self) -> Optional[LocalVariable]:
+        """The local variable on the RHS of the enclosing assignment, if any.
+
+        Resolves the common taint/aliasing pattern (``v5 = v3``) directly to
+        a :class:`LocalVariable`. Returns ``None`` if there's no enclosing
+        assignment, this reference is not on the LHS, or the RHS is anything
+        other than a plain variable.
+        """
+        rhs = self.assignment_rhs
+        if rhs is None or not rhs.is_variable or self.cfunc is None:
+            return None
+        idx = rhs.variable_index
+        if idx is None:
+            return None
+        return LocalVariable._from_raw(self.cfunc.raw_cfunc, idx)
+
+    @property
+    def containing_call(self) -> Optional[PseudocodeExpression]:
+        """Nearest enclosing call expression, if any.
+
+        Set when this reference is (transitively) inside a ``cot_call``
+        argument list. Lets callers identify the call site and inspect the
+        callee or sibling arguments without re-walking the tree.
+        """
+        for anc in self.walk_ancestors():
+            if anc.is_call:
+                return anc
+        return None
+
+    @property
+    def containing_call_args_lvars(self) -> Optional[List[Optional[LocalVariable]]]:
+        """Local variables passed as arguments to the enclosing call.
+
+        When this reference is inside a call's argument list, returns one
+        entry per arg position: a :class:`LocalVariable` when the arg is a
+        variable (directly, or wrapped in transparent ``cot_cast`` /
+        ``cot_ref`` nodes — ``(int)v``, ``&v``, ``(int)&v`` all resolve
+        to ``v``), ``None`` for arg positions occupied by something else
+        (a constant, an arithmetic expression, a call result, etc.).
+
+        Returns ``None`` when this reference is not inside a call.
+        """
+        call = self.containing_call
+        if call is None or self.cfunc is None:
+            return None
+        args = call.call_args
+        if args is None:
+            return None
+        raw_cfunc = self.cfunc.raw_cfunc
+        result: List[Optional[LocalVariable]] = []
+        for arg in args:
+            # Peel transparent wrappers — (int)v and &v still refer to v.
+            inner: Optional[PseudocodeExpression] = arg.expression
+            while inner is not None and inner.op in (
+                PseudocodeExpressionOp.CAST,
+                PseudocodeExpressionOp.REF,
+            ):
+                inner = inner.x
+            if inner is not None and inner.is_variable and inner.variable_index is not None:
+                result.append(LocalVariable._from_raw(raw_cfunc, inner.variable_index))
+            else:
+                result.append(None)
+        return result
+
+    def walk_ancestors(self) -> Iterator[PseudocodeExpression]:
+        """Yield ancestor expressions from innermost (parent) to outermost.
+
+        Thin delegate over :meth:`PseudocodeFunction.walk_ancestors_of`.
+        """
+        if self.cfunc is None or self.expr is None:
+            return
+        yield from self.cfunc.walk_ancestors_of(self.expr)
+
+
+# Parent operators that wrap a variable on the write side of an enclosing
+# assignment (e.g. ``HIWORD(v) = ...``, ``*v = ...``, ``v[i] = ...``).
+# When the immediate parent is one of these, we must walk up to find the
+# assignment and verify the variable is in its left subtree.
+_LVAR_WRITE_WRAPPING_OPS = frozenset({
+    PseudocodeExpressionOp.CALL,
+    PseudocodeExpressionOp.HELPER,
+    PseudocodeExpressionOp.CAST,
+    PseudocodeExpressionOp.PTR,
+    PseudocodeExpressionOp.MEMPTR,
+    PseudocodeExpressionOp.MEMREF,
+    PseudocodeExpressionOp.ADD,
+    PseudocodeExpressionOp.IDX,
+})
+
+
+def _is_in_left_subtree(
+    cfunc: PseudocodeFunction,
+    asg: PseudocodeExpression,
+    target: PseudocodeExpression,
+) -> bool:
+    """Return True if `target` lives anywhere under `asg.x`.
+
+    Walks UP from ``target`` looking for either ``asg.x`` (target is in
+    the left subtree) or ``asg`` itself (target lives in .y/.z instead).
+    Using ``walk_ancestors_of`` avoids manually enumerating every ctree
+    storage slot — ``find_parent_of`` already knows the layout, including
+    how Hex-Rays renders helpers like ``BYTE8(v)`` as
+    ``cot_call(cot_helper, [v])`` where ``v`` sits in the call's ``.a``
+    rather than a regular operand slot.
+    """
+    asg_x = asg.x
+    if asg_x is None:
+        return False
+    if target.raw_expr == asg_x.raw_expr:
+        return True
+    asg_raw = asg.raw_expr
+    asg_x_raw = asg_x.raw_expr
+    for anc in cfunc.walk_ancestors_of(target):
+        if anc.raw_expr == asg_x_raw:
+            return True
+        if anc.raw_expr == asg_raw:
+            return False
+    return False
+
+
+def _has_write_ancestor(cfunc: PseudocodeFunction, expr: PseudocodeExpression) -> bool:
+    """Walk ancestors of `expr`; return True if any ancestor is an assignment
+    and `expr` lives in that assignment's left subtree."""
+    for anc in cfunc.walk_ancestors_of(expr):
+        if anc.is_assignment:
+            return _is_in_left_subtree(cfunc, anc, expr)
+    return False
+
+
+def _classify_lvar_access(
+    cfunc: PseudocodeFunction,
+    expr: PseudocodeExpression,
+    parent: Optional[PseudocodeExpression],
+) -> LocalVariableAccessType:
+    """Determine read/write/address-taken classification for a variable reference."""
+    if parent is None:
+        return LocalVariableAccessType.READ
+
+    # Immediate parent is an assignment and expr is its direct LHS.
+    if parent.is_assignment and parent.raw_expr.x == expr.raw_expr:
+        return LocalVariableAccessType.WRITE
+
+    # Pre/post increment/decrement self-mutate their operand: ``v++``, ``--v``
+    # write to v, regardless of any enclosing expression.
+    if parent.op.is_prepost:
+        return LocalVariableAccessType.WRITE
+
+    # &var — may itself be on the write side of an enclosing assignment.
+    if parent.op == PseudocodeExpressionOp.REF:
+        if _has_write_ancestor(cfunc, expr):
+            return LocalVariableAccessType.WRITE
+        return LocalVariableAccessType.ADDRESS
+
+    # Variable wrapped in helper/cast/ptr/idx/etc. — check enclosing assignment.
+    if parent.op in _LVAR_WRITE_WRAPPING_OPS:
+        if _has_write_ancestor(cfunc, expr):
+            return LocalVariableAccessType.WRITE
+
+    return LocalVariableAccessType.READ
+
+
+def _classify_lvar_context(
+    cfunc: PseudocodeFunction,
+    expr: PseudocodeExpression,
+    parent: Optional[PseudocodeExpression],
+) -> LocalVariableContext:
+    """Determine usage context (assignment / call_arg / comparison / etc.)."""
+    if parent is None:
+        return LocalVariableContext.OTHER
+
+    pop = parent.op
+    if pop.is_assignment:
+        return LocalVariableContext.ASSIGNMENT
+    if pop == PseudocodeExpressionOp.CALL:
+        if _has_write_ancestor(cfunc, expr):
+            return LocalVariableContext.ASSIGNMENT
+        return LocalVariableContext.CALL_ARG
+    if pop.is_relational:
+        return LocalVariableContext.COMPARISON
+    if pop.is_arithmetic:
+        if _has_write_ancestor(cfunc, expr):
+            return LocalVariableContext.ASSIGNMENT
+        return LocalVariableContext.ARITHMETIC
+    if pop == PseudocodeExpressionOp.IDX:
+        if _has_write_ancestor(cfunc, expr):
+            return LocalVariableContext.ASSIGNMENT
+        return LocalVariableContext.ARRAY_INDEX
+    if pop in (
+        PseudocodeExpressionOp.PTR,
+        PseudocodeExpressionOp.MEMPTR,
+        PseudocodeExpressionOp.MEMREF,
+    ):
+        if _has_write_ancestor(cfunc, expr):
+            return LocalVariableContext.ASSIGNMENT
+        return LocalVariableContext.POINTER_DEREF
+    if pop == PseudocodeExpressionOp.CAST:
+        if _has_write_ancestor(cfunc, expr):
+            return LocalVariableContext.ASSIGNMENT
+        return LocalVariableContext.CAST
+    if pop in (PseudocodeExpressionOp.REF, PseudocodeExpressionOp.HELPER):
+        if _has_write_ancestor(cfunc, expr):
+            return LocalVariableContext.ASSIGNMENT
+        return LocalVariableContext.OTHER
+    return LocalVariableContext.OTHER
 
 
 # ---------------------------------------------------------------------------

--- a/ida_domain/pseudocode.py
+++ b/ida_domain/pseudocode.py
@@ -14,6 +14,7 @@ from typing_extensions import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     Generator,
     Iterator,
     List,
@@ -1994,6 +1995,10 @@ class PseudocodeFunction:
 
     def __init__(self, raw: cfuncptr_t):
         self._raw = raw
+        # Lazily built child->parent map for the whole ctree, keyed by node
+        # pointer identity. See :meth:`_parent_map`. Invalidated by
+        # :meth:`refresh` / :meth:`build_ctree`.
+        self._parent_map_cache: Optional[Dict[int, Any]] = None
 
     @property
     def raw_cfunc(self) -> cfuncptr_t:
@@ -2333,10 +2338,12 @@ class PseudocodeFunction:
     def refresh(self) -> None:
         """Refresh the pseudocode text after ctree modifications."""
         self._raw.refresh_func_ctext()
+        self._parent_map_cache = None
 
     def build_ctree(self) -> None:
         """Regenerate the function body from microcode."""
         self._raw.build_c_tree()
+        self._parent_map_cache = None
 
     # -- convenience tree traversal ----------------------------------------
 
@@ -2365,21 +2372,66 @@ class PseudocodeFunction:
 
     # -- tree navigation ----------------------------------------------------
 
+    def _parent_map(self) -> Dict[int, Any]:
+        """Build (once) and return a child->parent map for the whole ctree.
+
+        ``citem_t`` has no parent pointer, so a parent lookup must search a
+        subtree. This builds the full mapping in a single traversal, keyed by
+        node pointer identity, so subsequent lookups are O(1). The build is a
+        Python-callback pass over every node, so it only pays off across many
+        lookups on the same function — hence it is opt-in via the
+        ``use_cache`` argument of :meth:`find_parent_of` /
+        :meth:`walk_ancestors_of`. Invalidated by :meth:`refresh` /
+        :meth:`build_ctree`.
+
+        Values are the raw parent ``citem_t`` (``None`` for the root body).
+        """
+        if self._parent_map_cache is None:
+            parent_map: Dict[int, Any] = {}
+
+            class _ParentMapBuilder(ida_hexrays.ctree_visitor_t):
+                def __init__(self) -> None:
+                    super().__init__(ida_hexrays.CV_PARENTS)
+
+                def _record(self, item: Any) -> int:
+                    parent_map[int(item.this)] = self.parent_item()
+                    return 0
+
+                def visit_expr(self, expr: Any) -> int:
+                    return self._record(expr)
+
+                def visit_insn(self, insn: Any) -> int:
+                    return self._record(insn)
+
+            _ParentMapBuilder().apply_to(self._raw.body, None)
+            self._parent_map_cache = parent_map
+        return self._parent_map_cache
+
     def find_parent_of(
         self,
         item: Union[PseudocodeExpression, PseudocodeInstruction],
+        use_cache: bool = False,
     ) -> Optional[Union[PseudocodeExpression, PseudocodeInstruction]]:
         """Find the parent ctree item of the given expression or instruction.
 
         Args:
             item: A ``PseudocodeExpression`` or
                 ``PseudocodeInstruction`` whose parent to find.
+            use_cache: If ``False`` (default), do a native early-terminating
+                subtree search — cheapest for a one-off lookup. If ``True``,
+                build once and reuse a whole-function child->parent map
+                (see :meth:`_parent_map`); worthwhile only when doing many
+                lookups on the same function. The cache is invalidated by
+                :meth:`refresh` / :meth:`build_ctree`.
 
         Returns:
             The parent item wrapped as the appropriate type, or ``None``
             if not found.
         """
-        raw = self._raw.body.find_parent_of(item._raw)
+        if use_cache:
+            raw = self._parent_map().get(int(item._raw.this))
+        else:
+            raw = self._raw.body.find_parent_of(item._raw)
         if raw is None:
             return None
         if raw.is_expr():
@@ -2389,6 +2441,7 @@ class PseudocodeFunction:
     def walk_ancestors_of(
         self,
         item: PseudocodeExpression,
+        use_cache: bool = False,
     ) -> Iterator[PseudocodeExpression]:
         """Yield ancestor expressions of ``item`` from innermost to outermost.
 
@@ -2396,11 +2449,18 @@ class PseudocodeFunction:
         one specific ancestor pay only for the depth they actually visit.
         Stops at the first non-expression ancestor (a statement-level
         ``cinsn_t`` like a return or if-statement).
+
+        Args:
+            item: The expression whose ancestors to walk.
+            use_cache: Forwarded to :meth:`find_parent_of`. Pass ``True`` when
+                walking ancestors for many nodes on the same function (e.g.
+                reference analysis) so the per-level lookups share one cached
+                parent map instead of each re-searching the tree.
         """
-        cur = self.find_parent_of(item)
+        cur = self.find_parent_of(item, use_cache=use_cache)
         while isinstance(cur, PseudocodeExpression):
             yield cur
-            cur = self.find_parent_of(cur)
+            cur = self.find_parent_of(cur, use_cache=use_cache)
 
     # -- convenience finders -----------------------------------------------
 
@@ -2588,7 +2648,7 @@ class PseudocodeFunction:
         refs: List[LocalVariableReference] = []
         sv = None  # pseudocode lines, fetched lazily and reused across refs
         for expr in self.find_variables(var_index=var_index, var_name=var_name):
-            parent_item = self.find_parent_of(expr)
+            parent_item = self.find_parent_of(expr, use_cache=True)
             parent = parent_item if isinstance(parent_item, PseudocodeExpression) else None
 
             access_type = _classify_lvar_access(self, expr, parent)
@@ -2736,8 +2796,16 @@ class PseudocodeFunction:
 # analysis and variable access classification.
 #
 # Performance characteristics:
-#   - Walk-up: O(d) where d = ancestor depth, typically 1-5 levels
-#   - Invoked once per variable reference during classification
+#   - ``citem_t`` has no parent pointer, so a parent lookup means searching a
+#     subtree. The reference analysis below passes ``use_cache=True``, which
+#     builds a child->parent map for the whole function once (O(N), N = nodes)
+#     and then answers each parent lookup in O(1).
+#   - With that map, a walk-up of depth d is O(d).
+#   - A reference is walked several times (both classification passes via
+#     ``_has_write_ancestor``, which also walks ``_is_in_left_subtree``, plus
+#     the lazy ``assignment*`` / ``containing_call`` properties), but every
+#     walk shares the one cached map, so the per-function total is O(N + R*d)
+#     for R references of average ancestor depth d.
 #
 # ============================================================================
 
@@ -2843,7 +2911,7 @@ class LocalVariableReference:
         read, this is the assignment the read participates in (e.g. on the
         RHS); for a write, this is the assignment that performs the write.
         """
-        for anc in self.walk_ancestors():
+        for anc in self.walk_ancestors(use_cache=True):
             if anc.is_assignment:
                 return anc
         return None
@@ -2889,7 +2957,7 @@ class LocalVariableReference:
         argument list. Lets callers identify the call site and inspect the
         callee or sibling arguments without re-walking the tree.
         """
-        for anc in self.walk_ancestors():
+        for anc in self.walk_ancestors(use_cache=True):
             if anc.is_call:
                 return anc
         return None
@@ -2929,14 +2997,17 @@ class LocalVariableReference:
                 result.append(None)
         return result
 
-    def walk_ancestors(self) -> Iterator[PseudocodeExpression]:
+    def walk_ancestors(
+        self, use_cache: bool = False
+    ) -> Iterator[PseudocodeExpression]:
         """Yield ancestor expressions from innermost (parent) to outermost.
 
-        Thin delegate over :meth:`PseudocodeFunction.walk_ancestors_of`.
+        Thin delegate over :meth:`PseudocodeFunction.walk_ancestors_of`;
+        ``use_cache`` is forwarded there.
         """
         if self.cfunc is None or self.expr is None:
             return
-        yield from self.cfunc.walk_ancestors_of(self.expr)
+        yield from self.cfunc.walk_ancestors_of(self.expr, use_cache=use_cache)
 
 
 # Parent operators that wrap a variable on the write side of an enclosing
@@ -2977,7 +3048,7 @@ def _is_in_left_subtree(
         return True
     asg_raw = asg.raw_expr
     asg_x_raw = asg_x.raw_expr
-    for anc in cfunc.walk_ancestors_of(target):
+    for anc in cfunc.walk_ancestors_of(target, use_cache=True):
         if anc.raw_expr == asg_x_raw:
             return True
         if anc.raw_expr == asg_raw:
@@ -2988,7 +3059,7 @@ def _is_in_left_subtree(
 def _has_write_ancestor(cfunc: PseudocodeFunction, expr: PseudocodeExpression) -> bool:
     """Walk ancestors of `expr`; return True if any ancestor is an assignment
     and `expr` lives in that assignment's left subtree."""
-    for anc in cfunc.walk_ancestors_of(expr):
+    for anc in cfunc.walk_ancestors_of(expr, use_cache=True):
         if anc.is_assignment:
             return _is_in_left_subtree(cfunc, anc, expr)
     return False

--- a/ida_domain/pseudocode.py
+++ b/ida_domain/pseudocode.py
@@ -2586,6 +2586,7 @@ class PseudocodeFunction:
             List of classified references in walk order.
         """
         refs: List[LocalVariableReference] = []
+        sv = None  # pseudocode lines, fetched lazily and reused across refs
         for expr in self.find_variables(var_index=var_index, var_name=var_name):
             parent_item = self.find_parent_of(expr)
             parent = parent_item if isinstance(parent_item, PseudocodeExpression) else None
@@ -2599,7 +2600,8 @@ class PseudocodeFunction:
             coords = self._raw.find_item_coords(expr.raw_expr)
             if coords and len(coords) >= 2:
                 line_number = coords[1]
-                sv = self._raw.get_pseudocode()
+                if sv is None:
+                    sv = self._raw.get_pseudocode()
                 if 0 <= line_number < len(sv):
                     code_line = ida_lines.tag_remove(sv[line_number].line).strip()
 
@@ -2855,11 +2857,12 @@ class LocalVariableReference:
         being written, ``assignment_rhs`` is the expression whose value it
         receives.
         """
-        if self.assignment is None:
+        asg = self.assignment
+        if asg is None:
             return None
         if self.access_type != LocalVariableAccessType.WRITE:
             return None
-        return self.assignment.y
+        return asg.y
 
     @property
     def assignment_rhs_lvar(self) -> Optional[LocalVariable]:

--- a/ida_domain/pseudocode.py
+++ b/ida_domain/pseudocode.py
@@ -2393,8 +2393,15 @@ class PseudocodeFunction:
                 def __init__(self) -> None:
                     super().__init__(ida_hexrays.CV_PARENTS)
 
+                def _parent(self) -> Any:
+                    # parent_item() is available since IDA 9.2
+                    if hasattr(self, 'parent_item'):
+                        return self.parent_item()
+                    parents = self.parents
+                    return parents.back() if parents.size() else None
+
                 def _record(self, item: Any) -> int:
-                    parent_map[int(item.this)] = self.parent_item()
+                    parent_map[int(item.this)] = self._parent()
                     return 0
 
                 def visit_expr(self, expr: Any) -> int:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -102,7 +102,7 @@ def test_function(test_env):
     refs = db.functions.get_local_variable_references(func, local_var)
     assert len(refs) == 1
 
-    from ida_domain.functions import LocalVariableAccessType, LocalVariableContext
+    from ida_domain.pseudocode import LocalVariableAccessType, LocalVariableContext
 
     first_ref = refs[0]
     assert first_ref.access_type == LocalVariableAccessType.READ
@@ -121,6 +121,46 @@ def test_function(test_env):
     assert write_refs[0].access_type == LocalVariableAccessType.WRITE
     assert write_refs[0].context == LocalVariableContext.ASSIGNMENT
     assert write_refs[0].code_line == 'v5 = v3;'
+
+    # Each ref carries the wrapped expr, parent, lazy assignment, and
+    # walk_ancestors() so callers can do deeper analyses without dropping
+    # into raw SWIG ctree walking.
+    from ida_domain.pseudocode import PseudocodeExpression, PseudocodeFunction
+
+    write_ref = write_refs[0]
+    assert isinstance(write_ref.expr, PseudocodeExpression)
+    assert write_ref.expr.is_variable
+    assert write_ref.expr.variable_index == v5_var.index
+    assert isinstance(write_ref.parent, PseudocodeExpression)
+    assert write_ref.parent.is_assignment
+    assert isinstance(write_ref.assignment, PseudocodeExpression)
+    assert write_ref.assignment.is_assignment
+    # assignment_rhs on a WRITE returns the RHS expression of the assignment
+    rhs = write_ref.assignment_rhs
+    assert isinstance(rhs, PseudocodeExpression)
+    assert rhs.is_variable  # v3
+    # assignment_rhs_lvar resolves the RHS directly to a LocalVariable
+    rhs_lvar = write_ref.assignment_rhs_lvar
+    from ida_domain.pseudocode import LocalVariable
+    assert isinstance(rhs_lvar, LocalVariable)
+    assert rhs_lvar.name == 'v3'
+    # This write is not inside a call, so containing_call_args_lvars is None
+    assert write_ref.containing_call_args_lvars is None
+    # walk_ancestors() yields lazily; innermost first
+    ancestors = list(write_ref.walk_ancestors())
+    assert len(ancestors) >= 1
+    assert ancestors[0].is_assignment
+    # cfunc keeps the wrapper layer alive
+    assert isinstance(write_ref.cfunc, PseudocodeFunction)
+
+    # A READ reference (e.g. a3 on the RHS of *((_QWORD *)&v3 + 1) = a3;)
+    # does NOT expose assignment_rhs (that's only for writes), but its
+    # `assignment` ancestor is still populated.
+    a3_ref = refs[0]
+    assert a3_ref.access_type == LocalVariableAccessType.READ
+    assert a3_ref.assignment_rhs is None
+    assert isinstance(a3_ref.assignment, PseudocodeExpression)
+    assert a3_ref.assignment.is_assignment
 
     func = db.functions.get_at(0x311)
     assert func is not None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -190,7 +190,7 @@ def test_complex_variable_access(tiny_c_env):
     - LOWORD(v9) = a2;  -> WRITE / ASSIGNMENT
     - use_val(v9);      -> READ / CALL_ARG
     """
-    from ida_domain.functions import LocalVariableAccessType, LocalVariableContext
+    from ida_domain.pseudocode import LocalVariableAccessType, LocalVariableContext
 
     db = tiny_c_env
 

--- a/tests/test_pseudocode.py
+++ b/tests/test_pseudocode.py
@@ -2427,7 +2427,7 @@ def test_containing_call_args_lvars_consistency(test_env):
                 assert call.is_call
                 args = ref.containing_call_args_lvars
                 assert args is not None
-                assert len(args) == len(list(call.call_args))
+                assert len(args) == len(call.call_args)
                 for a in args:
                     assert a is None or isinstance(a, LocalVariable)
                 checked_refs += 1

--- a/tests/test_pseudocode.py
+++ b/tests/test_pseudocode.py
@@ -5,6 +5,9 @@ import ida_domain  # isort: skip
 
 from ida_domain.microcode import MicroLocalVar  # noqa: E402
 from ida_domain.pseudocode import (  # noqa: E402
+    LocalVariable,
+    LocalVariableAccessType,
+    LocalVariableReference,
     PseudocodeBlock,
     PseudocodeExpression,
     PseudocodeExpressionOp,
@@ -2050,5 +2053,432 @@ def test_add_comment_accepts_comment_placement_enum(test_env):
     # remove_comment accepts the enum and clears the stored entry.
     func.remove_comment(ea, placement=CommentPlacement.SEMI)
     assert func.get_comment(ea) is None
+
+
+# ---------------------------------------------------------------------------
+# PseudocodeFunction.find_variable_references + LocalVariableReference helpers
+# ---------------------------------------------------------------------------
+#
+# Test fixture — function at 0x2D0 in tiny_asm.bin (`print_number`):
+#
+#     signed __int64 __fastcall print_number(__int64 a1, __int64 a2, __int64 a3)
+#     {
+#       unsigned __int128 v3;          // rax
+#       const char *v4;                // rsi
+#       unsigned __int128 v5;          // rtt
+#       int v7;                        // [rsp+0h]  BYREF
+#       _UNKNOWN *retaddr;             // [rsp+14h] BYREF
+#
+#       *((_QWORD *)&v3 + 1) = a3;          // a3 READ; v3 nested-WRITE
+#       v4 = (const char *)&v7;             // v4 WRITE; v7 ADDRESS
+#       *((_QWORD *)&v3 + 1) = 0;           // v3 nested-WRITE
+#       do
+#       {
+#         v5 = v3;                          // v5 WRITE; v3 READ   ← anchor
+#         *(_QWORD *)&v3 = v3 / 0xA;        // v3 nested-WRITE; v3 READ
+#         *((_QWORD *)&v3 + 1) = v5 % 0xA;  // v3 nested-WRITE; v5 READ
+#         BYTE8(v3) += 48;                  // v3 compound-WRITE (via cot_call.a)
+#         *--v4 = BYTE8(v3);                // v4 nested-WRITE (predec); v3 READ
+#       }
+#       while ( (_QWORD)v3 );               // v3 READ
+#       return sys_write(1u, v4, (char *)&retaddr - v4);  // v4×2 R, retaddr ADDR
+#     }
+
+def _walk_cot_vars(pcfunc, var_index):
+    """Helper: enumerate all cot_var cexpr_t nodes matching var_index by
+    walking the ctree directly. Used as the ground-truth oracle for
+    find_variable_references() count assertions.
+    """
+    found = []
+    for expr in pcfunc.walk_expressions():
+        if expr.is_variable and expr.variable_index == var_index:
+            found.append(expr)
+    return found
+
+
+def test_find_variable_references_count_matches_walk(test_env):
+    """find_variable_references(var_index=i) returns one ref per cot_var
+    occurrence — should match a direct walk of the ctree.
+
+    Corpus: print_number (see header). v3 appears many times (in the
+    nested writes and arithmetic), v4 appears multiple times (writes
+    and call args), a3 once (RHS of the first assignment), etc.
+    Property: count(find_variable_references) == count(walk_expressions
+    filtered by `is_variable and variable_index == i`).
+    """
+    db = test_env
+    pcfunc = db.pseudocode.decompile(0x2D0)
+    lvars = db.functions.get_local_variables(db.functions.get_at(0x2D0))
+    assert len(lvars) > 0
+
+    for lvar in lvars:
+        refs = pcfunc.find_variable_references(var_index=lvar.index)
+        ground_truth = _walk_cot_vars(pcfunc, lvar.index)
+        assert len(refs) == len(ground_truth), (
+            f"{lvar.name}: find_variable_references returned {len(refs)} "
+            f"but ctree walk found {len(ground_truth)} cot_var occurrences"
+        )
+
+
+def test_find_variable_references_expr_is_cot_var(test_env):
+    """Every returned ref's expr is a cot_var leaf with matching index."""
+    db = test_env
+    pcfunc = db.pseudocode.decompile(0x2D0)
+    lvars = db.functions.get_local_variables(db.functions.get_at(0x2D0))
+
+    total = 0
+    for lvar in lvars:
+        for ref in pcfunc.find_variable_references(var_index=lvar.index):
+            assert isinstance(ref.expr, PseudocodeExpression)
+            assert ref.expr.is_variable
+            assert ref.expr.variable_index == lvar.index
+            assert ref.expr.op == PseudocodeExpressionOp.VAR
+            total += 1
+    assert total > 0, "expected at least one variable reference in func 0x2D0"
+
+
+def test_find_variable_references_parent_matches_find_parent_of(test_env):
+    """ref.parent is what cfunc.find_parent_of(ref.expr) returns (when an expr).
+
+    Corpus: print_number (see header). Examples:
+      - `v5 = v3;`             → v5's parent is cot_asg (expr → ref.parent set)
+      - `return sys_write(…)`  → v4's parent is the cot_call (expr → ref.parent set)
+      - `*--v4 = …`            → v4's parent is cot_predec (expr → ref.parent set)
+    """
+    db = test_env
+    pcfunc = db.pseudocode.decompile(0x2D0)
+    lvars = db.functions.get_local_variables(db.functions.get_at(0x2D0))
+
+    checked = 0
+    for lvar in lvars:
+        for ref in pcfunc.find_variable_references(var_index=lvar.index):
+            direct_parent = pcfunc.find_parent_of(ref.expr)
+            if isinstance(direct_parent, PseudocodeExpression):
+                # ref.parent should wrap the same raw cexpr_t
+                assert ref.parent is not None
+                assert ref.parent.raw_expr == direct_parent.raw_expr
+                checked += 1
+            else:
+                # Parent is a statement (cinsn_t) — ref.parent should be None
+                assert ref.parent is None
+    assert checked > 0
+
+
+def test_find_variable_references_write_has_assignment(test_env):
+    """Every WRITE ref must have a non-None .assignment whose op is an
+    assignment (the access classifier and the lazy walk agree).
+
+    Corpus: print_number (see header). Stress-tests nested writes:
+    ``*((_QWORD *)&v3 + 1) = a3`` (WRITE via deref+add+ref),
+    ``BYTE8(v3) += 48`` (WRITE via compound asg + cot_call.a),
+    ``*--v4 = …`` (WRITE via self-mutating predec).
+    """
+    db = test_env
+    pcfunc = db.pseudocode.decompile(0x2D0)
+    lvars = db.functions.get_local_variables(db.functions.get_at(0x2D0))
+
+    saw_write = False
+    for lvar in lvars:
+        for ref in pcfunc.find_variable_references(var_index=lvar.index):
+            if ref.access_type == LocalVariableAccessType.WRITE:
+                saw_write = True
+                assert ref.assignment is not None, (
+                    f"WRITE ref for {lvar.name} at line {ref.line_number} "
+                    f"has no enclosing assignment"
+                )
+                assert ref.assignment.is_assignment
+    assert saw_write, "expected at least one WRITE in func 0x2D0"
+
+
+def test_walk_ancestors_yields_expressions_only(test_env):
+    """walk_ancestors stops at the first non-expression ancestor.
+
+    Corpus: print_number (see header). The chain for v3 in
+    ``*((_QWORD *)&v3 + 1) = a3;`` climbs
+    cot_var -> cot_ref -> cot_cast -> cot_ptr -> cot_add -> cot_asg -> cit_expr.
+    walk_ancestors yields the cexpr_t ancestors and stops at cit_expr.
+    """
+    db = test_env
+    pcfunc = db.pseudocode.decompile(0x2D0)
+    lvars = db.functions.get_local_variables(db.functions.get_at(0x2D0))
+
+    checked = 0
+    for lvar in lvars:
+        for ref in pcfunc.find_variable_references(var_index=lvar.index):
+            for anc in ref.walk_ancestors():
+                assert isinstance(anc, PseudocodeExpression)
+                checked += 1
+    assert checked > 0
+
+
+def test_walk_ancestors_first_is_immediate_parent(test_env):
+    """If ref.parent is set, walk_ancestors's first yield is the same
+    expression (innermost-first contract)."""
+    db = test_env
+    pcfunc = db.pseudocode.decompile(0x2D0)
+    lvars = db.functions.get_local_variables(db.functions.get_at(0x2D0))
+
+    checked = 0
+    for lvar in lvars:
+        for ref in pcfunc.find_variable_references(var_index=lvar.index):
+            ancestors = list(ref.walk_ancestors())
+            if ref.parent is not None:
+                assert len(ancestors) >= 1
+                assert ancestors[0].raw_expr == ref.parent.raw_expr
+                checked += 1
+    assert checked > 0
+
+
+def test_assignment_rhs_matches_assignment_y(test_env):
+    """For a WRITE ref, assignment_rhs is the .y of the enclosing assignment.
+
+    Corpus: print_number (see header). Examples checked across all WRITE refs:
+    ``v5 = v3`` (.y is cot_var v3),
+    ``... = a3`` (.y is cot_var a3),
+    ``... = v3 / 0xA`` (.y is cot_sdiv),
+    ``BYTE8(v3) += 48`` (.y is cot_num 48).
+    """
+    db = test_env
+    pcfunc = db.pseudocode.decompile(0x2D0)
+    lvars = db.functions.get_local_variables(db.functions.get_at(0x2D0))
+
+    checked = 0
+    for lvar in lvars:
+        for ref in pcfunc.find_variable_references(var_index=lvar.index):
+            if ref.access_type == LocalVariableAccessType.WRITE and ref.assignment:
+                rhs = ref.assignment_rhs
+                assert rhs is not None
+                assert rhs.raw_expr == ref.assignment.y.raw_expr
+                checked += 1
+    assert checked > 0
+
+
+def test_assignment_rhs_lvar_v5_eq_v3(test_env):
+    """The only WRITE to v5 in print_number is the canonical copy:
+
+        v5 = v3;       // ref.assignment is this cot_asg
+                       // ref.assignment_rhs is the cot_var on .y
+                       // ref.assignment_rhs_lvar is LocalVariable("v3")
+    """
+    db = test_env
+    func = db.functions.get_at(0x2D0)
+    pcfunc = db.pseudocode.decompile(func)
+
+    v5_refs = pcfunc.find_variable_references(var_name='v5')
+    writes = [r for r in v5_refs if r.access_type == LocalVariableAccessType.WRITE]
+    assert len(writes) == 1, "expected exactly one WRITE for v5 (the v5 = v3;)"
+
+    write = writes[0]
+    assert write.code_line == 'v5 = v3;'
+
+    source = write.assignment_rhs_lvar
+    assert isinstance(source, LocalVariable)
+    assert source.name == 'v3'
+
+    # Cross-check: the assignment node's y operand is a plain cot_var with
+    # variable_index pointing at v3's slot.
+    rhs = write.assignment_rhs
+    assert rhs is not None
+    assert rhs.is_variable
+    assert rhs.variable_index == source.index
+
+
+def test_assignment_rhs_lvar_none_for_read_refs(test_env):
+    """a3 only appears once in print_number, on the RHS of an assignment:
+
+        *((_QWORD *)&v3 + 1) = a3;    // a3 is READ here, never written
+
+    So every a3 reference is READ, and assignment_rhs_lvar must be None
+    per its contract (it only resolves when the ref is on the LHS).
+    """
+    db = test_env
+    func = db.functions.get_at(0x2D0)
+    pcfunc = db.pseudocode.decompile(func)
+
+    a3_refs = pcfunc.find_variable_references(var_name='a3')
+    assert len(a3_refs) >= 1
+    for ref in a3_refs:
+        if ref.access_type != LocalVariableAccessType.WRITE:
+            assert ref.assignment_rhs_lvar is None
+
+
+def test_containing_call_args_lvars_sys_write(test_env):
+    """print_number ends with a 3-arg call:
+
+        return sys_write(1u, v4, (char *)&retaddr - v4);
+                         |   |   |
+                         |   |   └── cot_sub (expression, not a var)
+                         |   └────── cot_var (direct v4)
+                         └────────── cot_num (constant 1u)
+
+    For any ref to v4 inside this call, containing_call_args_lvars should
+    return [None, LocalVariable("v4"), None] — the cast/ref peel does not
+    recurse into cot_sub, so position 2 stays None even though retaddr/v4
+    live inside it.
+    """
+    db = test_env
+    func = db.functions.get_at(0x2D0)
+    pcfunc = db.pseudocode.decompile(func)
+
+    # Walk to find the sys_write call by name
+    calls = pcfunc.find_calls(target_name='sys_write')
+    assert len(calls) == 1, "expected exactly one sys_write call"
+    call = calls[0]
+
+    args = list(call.call_args)
+    assert len(args) == 3
+
+    # Build the expected lvar list directly from the call expression
+    # (this is the same computation the property performs, used here as
+    # a redundant ground-truth check).
+    v4_lvar = next(
+        lv for lv in db.functions.get_local_variables(func) if lv.name == 'v4'
+    )
+
+    # Grab any reference to v4 that sits inside this call — that ref's
+    # containing_call_args_lvars should match the call's args.
+    v4_refs = [
+        r for r in pcfunc.find_variable_references(var_index=v4_lvar.index)
+        if r.containing_call is not None
+    ]
+    assert len(v4_refs) > 0, "expected at least one v4 ref inside sys_write"
+
+    for ref in v4_refs:
+        assert ref.containing_call.raw_expr == call.raw_expr
+        args_lvars = ref.containing_call_args_lvars
+        assert args_lvars is not None
+        assert len(args_lvars) == 3
+        # Position 0: the constant 1u → None
+        assert args_lvars[0] is None
+        # Position 1: v4 directly → LocalVariable for v4
+        assert isinstance(args_lvars[1], LocalVariable)
+        assert args_lvars[1].name == 'v4'
+        # Position 2: arithmetic expression (cot_sub) wrapping retaddr and v4
+        # → not a plain variable after cast/ref peel → None
+        assert args_lvars[2] is None
+
+
+def test_containing_call_args_lvars_consistency(test_env):
+    """For every reference that sits inside a call's argument list across
+    the whole binary, containing_call_args_lvars has one entry per arg,
+    each entry is either a LocalVariable or None, and the length matches
+    the call's actual arg count."""
+    db = test_env
+    checked_refs = 0
+
+    for func in db.functions:
+        try:
+            pcfunc = db.pseudocode.decompile(func)
+        except Exception:
+            continue
+        if not pcfunc.find_calls():
+            continue
+
+        for lvar in db.functions.get_local_variables(func):
+            for ref in pcfunc.find_variable_references(var_index=lvar.index):
+                call = ref.containing_call
+                if call is None:
+                    assert ref.containing_call_args_lvars is None
+                    continue
+                assert call.is_call
+                args = ref.containing_call_args_lvars
+                assert args is not None
+                assert len(args) == len(list(call.call_args))
+                for a in args:
+                    assert a is None or isinstance(a, LocalVariable)
+                checked_refs += 1
+
+    assert checked_refs > 0, (
+        "expected at least one lvar reference inside a call across the binary"
+    )
+
+
+def test_print_number_ref_counts_hardcoded(test_env):
+    """Hand-counted reference and access-type counts derived from
+    print_number's pseudocode (see section header).
+
+    Each tuple is (total_refs, writes, reads, addresses) per lvar:
+
+      a1, a2:    declared but never referenced in body
+      a3:        RHS of `*((_QWORD *)&v3 + 1) = a3;`
+      v3:        nested-W in `*((_QWORD *)&v3 + 1) = a3;`
+                 nested-W in `*((_QWORD *)&v3 + 1) = 0;`
+                 R on RHS of `v5 = v3;`
+                 W (LHS *(_QWORD *)&v3 = …) + R (RHS v3 / 0xA)
+                 nested-W in `*((_QWORD *)&v3 + 1) = v5 % 0xA;`
+                 W via compound asg in `BYTE8(v3) += 48;`
+                 R in `BYTE8(v3)` on RHS of `*--v4 = …`
+                 R in the while condition cast
+      v4:        direct W (`v4 = (const char *)&v7;`)
+                 nested-W via predec (`*--v4 = …`)
+                 R x2 in `sys_write(1u, v4, … - v4)`
+      v5:        LHS W in `v5 = v3;`; R in `v5 % 0xA`
+      v7:        `&v7` — ADDRESS (no enclosing write to v7)
+      retaddr:   `&retaddr` — ADDRESS
+
+    If any of these don't match the live classifier, either the manual
+    count is wrong or the classifier has regressed.
+    """
+    db = test_env
+    func = db.functions.get_at(0x2D0)
+    pcfunc = db.pseudocode.decompile(func)
+
+    # (total, writes, reads, addresses)
+    expected = {
+        'a1':      (0, 0, 0, 0),
+        'a2':      (0, 0, 0, 0),
+        'a3':      (1, 0, 1, 0),
+        'v3':      (9, 5, 4, 0),
+        'v4':      (4, 2, 2, 0),
+        'v5':      (2, 1, 1, 0),
+        'v7':      (1, 0, 0, 1),
+        'retaddr': (1, 0, 0, 1),
+    }
+
+    seen = set()
+    for lvar in db.functions.get_local_variables(func):
+        if lvar.name not in expected:
+            continue
+        seen.add(lvar.name)
+        refs = pcfunc.find_variable_references(var_index=lvar.index)
+        total = len(refs)
+        writes = sum(1 for r in refs if r.access_type == LocalVariableAccessType.WRITE)
+        reads = sum(1 for r in refs if r.access_type == LocalVariableAccessType.READ)
+        addresses = sum(
+            1 for r in refs if r.access_type == LocalVariableAccessType.ADDRESS
+        )
+        exp = expected[lvar.name]
+        assert (total, writes, reads, addresses) == exp, (
+            f"{lvar.name}: expected (total,W,R,A)={exp}, "
+            f"got ({total},{writes},{reads},{addresses})"
+        )
+
+    # Sanity: every expected lvar was actually present in the function
+    assert seen == set(expected.keys()), (
+        f"missing lvars in print_number: {set(expected.keys()) - seen}"
+    )
+
+
+def test_containing_call_none_when_not_in_call(test_env):
+    """For refs not nested inside any call, containing_call must be None
+    and containing_call_args_lvars must be None.
+
+    Corpus: print_number (see header). Most refs live in plain assignments
+    or the do-while condition — none have a cot_call ancestor, so they all
+    report containing_call=None. Only the trailing sys_write call exercises
+    the opposite path (covered by the sys_write-specific test).
+    """
+    db = test_env
+    pcfunc = db.pseudocode.decompile(0x2D0)
+    lvars = db.functions.get_local_variables(db.functions.get_at(0x2D0))
+
+    found_one = False
+    for lvar in lvars:
+        for ref in pcfunc.find_variable_references(var_index=lvar.index):
+            if not any(a.is_call for a in ref.walk_ancestors()):
+                assert ref.containing_call is None
+                assert ref.containing_call_args_lvars is None
+                found_one = True
+    assert found_one
 
 

--- a/tests/test_pseudocode.py
+++ b/tests/test_pseudocode.py
@@ -199,6 +199,50 @@ def test_find_parent_of_call_target(test_env):
     assert parent.is_call
 
 
+def test_find_parent_of_cache_matches_native(test_env):
+    """The cached parent map (use_cache=True) yields identical parents to the
+    native search (use_cache=False) for every node in the ctree.
+
+    Corpus: print_number (0x2D0) — a rich nested tree (deref/add/ref chains,
+    calls, compound assignments) that exercises every ctree storage slot.
+    Checks both the immediate parent of every node and the full ancestor
+    chain of every expression.
+    """
+    db = test_env
+    func = db.pseudocode.decompile(0x2D0)
+
+    def node_id(node):
+        # Pointer identity is the cache key; None for "no parent".
+        return None if node is None else int(node._raw.this)
+
+    # Immediate parent of every node (expressions and instructions).
+    nodes_checked = 0
+    for node in func.walk_all():
+        native = func.find_parent_of(node, use_cache=False)
+        cached = func.find_parent_of(node, use_cache=True)
+        assert node_id(cached) == node_id(native), (
+            f"parent mismatch for {node.op.name} at 0x{node.ea:x}"
+        )
+        assert type(cached) is type(native)
+        nodes_checked += 1
+    assert nodes_checked > 0
+
+    # Full ancestor chain of every expression.
+    chains_checked = 0
+    for expr in func.walk_expressions():
+        native_chain = [
+            node_id(a) for a in func.walk_ancestors_of(expr, use_cache=False)
+        ]
+        cached_chain = [
+            node_id(a) for a in func.walk_ancestors_of(expr, use_cache=True)
+        ]
+        assert cached_chain == native_chain, (
+            f"ancestor chain mismatch for {expr.op.name} at 0x{expr.ea:x}"
+        )
+        chains_checked += 1
+    assert chains_checked > 0
+
+
 # ---------------------------------------------------------------------------
 # MicroLocalVar.set_user_comment
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
  What's new on `LocalVariableReference`:
  - `expr`, `parent`, `cfunc` - wrapped ctree access
  - `assignment`, `assignment_rhs` - nearest enclosing assignment + its RHS
  - `assignment_rhs_lvar` - RHS resolved straight to a LocalVariable (covers the v1 = a5 pattern)
  - `containing_call`, `containing_call_args_lvars` - enclosing call + its args as LocalVariables
  - `walk_ancestors()` - lazy ancestor iterator

Fixed:
  - *--v = … and other pre/post inc/dec patterns now correctly classify as WRITE.

As there is pseudocode module now, some things were moved from functions to pseudocode