### PR TITLE
Add IDA 9.4 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,6 @@ jobs:
           echo "Installing hcli..."
           uv tool install ida-hcli==0.18.1
           echo "Downloading and installing IDA ${{ matrix.ida_version.version }}..."
-          mkdir -p /opt/ida/
           hcli ida install -y -d ${{ matrix.ida_version.installer_path }} -l ${{ secrets.IDA_LICENSE_ID }} -i /opt/ida/
           echo "Done!"
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install IDA ${{ matrix.ida_version.version }}
         run: |
           echo "Installing hcli..."
-          uv tool install ida-hcli==0.6.0
+          uv tool install ida-hcli==0.18.1
           echo "Downloading and installing IDA ${{ matrix.ida_version.version }}..."
           mkdir -p /opt/ida/
           hcli ida install -d ${{ matrix.ida_version.installer_path }} -l ${{ secrets.IDA_LICENSE_ID }} -i /opt/ida/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,8 @@ jobs:
             installer_path: "release/9.2/ida-pro/ida-pro_92_x64linux.run"
           - version: "9.3"
             installer_path: "release/9.3/ida-pro/ida-pro_93_x64linux.run"
+          - version: "9.4-beta-1"
+            installer_path: "beta/ida-pro/9.4-beta-1/ida-pro_94_x64linux.run"
       fail-fast: false
 
     name: Running tests on IDA ${{ matrix.ida_version.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
           uv tool install ida-hcli==0.18.1
           echo "Downloading and installing IDA ${{ matrix.ida_version.version }}..."
           mkdir -p /opt/ida/
-          hcli ida install -d ${{ matrix.ida_version.installer_path }} -l ${{ secrets.IDA_LICENSE_ID }} -i /opt/ida/
+          hcli ida install -y -d ${{ matrix.ida_version.installer_path }} -l ${{ secrets.IDA_LICENSE_ID }} -i /opt/ida/
           echo "Done!"
         env:
           HCLI_API_KEY: ${{ secrets.HCLI_API_KEY }}


### PR DESCRIPTION
## Add IDA 9.4 to the test matrix

  Adds the upcoming IDA 9.4 series to the `tests.yml` matrix (alongside 9.1 /
  9.2 / 9.3) so we catch regressions against it before the final release lands,
  rather than discovering them on release day.
  
  This PR **is intended to stay open until IDA 9.4 final is released**. While it's
  open we'll keep the matrix entry pointed at the latest 9.4 beta — bumping the
  `installer_path` (`9.4-beta-1` → later betas/EAPs) as new builds ship. Once 9.4
  goes GA, the final step is to flip the entry to the `release/9.4/...` installer
  path (matching the 9.1–9.3 rows) and merge.
    
