### PR TITLE
Add quotes to path parameters (#93)

### DIFF
--- a/ida_domain/database.py
+++ b/ida_domain/database.py
@@ -273,11 +273,11 @@ class IdaCommandOptions:
         if self.jit_debugger is not None:
             args.append(f'-I{int(self.jit_debugger)}')
         if self.log_file:
-            args.append(f'-L"{self.log_file}"')
+            args.append(f'-L{self._quote(self.log_file)}')
         if self.disable_mouse:
             args.append('-M')
         if self.output_database:
-            args.append(f'-o"{self.output_database}"')
+            args.append(f'-o{self._quote(self.output_database)}')
         if self.plugin_options:
             args.append(f'-O{self.plugin_options}')
         if self.processor:
@@ -298,18 +298,18 @@ class IdaCommandOptions:
                 f' {self._quote_if_needed(arg)}' for arg in self.script_args
             )
             if self.script_args:
-                args.append(f'-S"{full}"')
+                args.append(f'-S{self._quote(full)}')
             else:
-                args.append(f'-S"{self.script_file}"')
+                args.append(f'-S{self._quote(self.script_file)}')
         if self.empty_database:
             args.append('-t')
         if self.file_type:
             type_spec = self.file_type
             if self.file_member:
                 type_spec += f':{self.file_member}'
-            args.append(f'-T"{type_spec}"')
+            args.append(f'-T{self._quote(type_spec)}')
         if self.windows_dir:
-            args.append(f'-W"{self.windows_dir}"')
+            args.append(f'-W{self._quote(self.windows_dir)}')
         if self.no_segmentation:
             args.append('-x')
         if self.debug_flags:
@@ -320,9 +320,17 @@ class IdaCommandOptions:
         return ' '.join(args)
 
     @staticmethod
+    def _quote(s: str) -> str:
+        """Quote a string, escaping quotes and trailing backslashes."""
+        s = s.replace('"', r'\"')
+        if s.endswith('\\'):
+            s += '\\'
+        return f'"{s}"'
+
+    @staticmethod
     def _quote_if_needed(s: str) -> str:
         """Quote a string if it contains spaces."""
-        return f'"{s}"' if ' ' in s else s
+        return IdaCommandOptions._quote(s) if ' ' in s else s
 
     @staticmethod
     def _parse_debug_flags(flags: Union[int, List[str]]) -> int:

--- a/ida_domain/database.py
+++ b/ida_domain/database.py
@@ -273,11 +273,11 @@ class IdaCommandOptions:
         if self.jit_debugger is not None:
             args.append(f'-I{int(self.jit_debugger)}')
         if self.log_file:
-            args.append(f'-L{self.log_file}')
+            args.append(f'-L"{self.log_file}"')
         if self.disable_mouse:
             args.append('-M')
         if self.output_database:
-            args.append(f'-o{self.output_database}')
+            args.append(f'-o"{self.output_database}"')
         if self.plugin_options:
             args.append(f'-O{self.plugin_options}')
         if self.processor:
@@ -300,16 +300,16 @@ class IdaCommandOptions:
             if self.script_args:
                 args.append(f'-S"{full}"')
             else:
-                args.append(f'-S{self.script_file}')
+                args.append(f'-S"{self.script_file}"')
         if self.empty_database:
             args.append('-t')
         if self.file_type:
-            type_spec = f'-T{self.file_type}'
+            type_spec = self.file_type
             if self.file_member:
                 type_spec += f':{self.file_member}'
-            args.append(type_spec)
+            args.append(f'-T"{type_spec}"')
         if self.windows_dir:
-            args.append(f'-W{self.windows_dir}')
+            args.append(f'-W"{self.windows_dir}"')
         if self.no_segmentation:
             args.append('-x')
         if self.debug_flags:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -109,11 +109,12 @@ def test_database(test_env):
 @min_ida_version('9.2')
 def test_file_type_with_spaces():
     """file_type values with spaces must reach IDA as a single -T argument."""
-    opts = IdaCommandOptions(new_database=True, file_type='ELF64 for x86-64 (Relocatable)')
+    # 'Binary file' differs from the auto-detected ELF format, proving -T was applied
+    opts = IdaCommandOptions(new_database=True, file_type='Binary file')
     db = ida_domain.Database.open(path=conftest.idb_path, args=opts, save_on_close=False)
     try:
         assert db.is_open()
-        assert db.format == 'ELF64 for x86-64 (Relocatable)'
+        assert db.format == 'Binary file'
     finally:
         db.close(False)
 
@@ -147,7 +148,9 @@ def test_output_database_with_spaces():
 @min_ida_version('9.2')
 def test_windows_dir_with_spaces():
     """windows_dir paths with spaces must reach IDA as a single -W argument."""
-    opts = IdaCommandOptions(new_database=True, windows_dir='C:\\Program Files')
+    opts = IdaCommandOptions(new_database=True, windows_dir='C:\\Program Files\\')
+    # trailing backslashes must be doubled, otherwise \" is parsed as a literal quote
+    assert opts.build_args() == '-c -W"C:\\Program Files\\\\"'
     db = ida_domain.Database.open(path=conftest.idb_path, args=opts, save_on_close=False)
     try:
         assert db.is_open()
@@ -230,6 +233,9 @@ def test_ida_command_options():
     opts = IdaCommandOptions(log_file='debug.log')
     assert opts.build_args() == '-L"debug.log"'
 
+    opts = IdaCommandOptions(log_file='we"ird log.txt')
+    assert opts.build_args() == '-L"we\\"ird log.txt"'
+
     # Test disable mouse option
     opts = IdaCommandOptions(disable_mouse=True)
     assert opts.build_args() == '-M'
@@ -273,7 +279,7 @@ def test_ida_command_options():
 
     args = ['arg1', 'arg with spaces', '--flag=value']
     opts = IdaCommandOptions(script_file='script.py', script_args=args)
-    assert opts.build_args() == '-S"script.py arg1 "arg with spaces" --flag=value"'
+    assert opts.build_args() == '-S"script.py arg1 \\"arg with spaces\\" --flag=value"'
 
     # Test file type option
     opts = IdaCommandOptions(file_type='PE')

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,3 +1,5 @@
+import os
+
 import conftest
 
 import ida_domain  # isort: skip
@@ -103,6 +105,70 @@ def test_database(test_env):
     db3.close(False)
 
 
+def test_file_type_with_spaces():
+    """file_type values with spaces must reach IDA as a single -T argument."""
+    opts = IdaCommandOptions(new_database=True, file_type='ELF64 for x86-64 (Relocatable)')
+    db = ida_domain.Database.open(path=conftest.idb_path, args=opts, save_on_close=False)
+    try:
+        assert db.is_open()
+        assert db.format == 'ELF64 for x86-64 (Relocatable)'
+    finally:
+        db.close(False)
+
+
+def test_log_file_with_spaces():
+    """log_file paths with spaces must reach IDA as a single -L argument."""
+    log_file = os.path.join(os.path.dirname(conftest.idb_path), 'log with spaces.txt')
+
+    opts = IdaCommandOptions(new_database=True, log_file=log_file)
+    db = ida_domain.Database.open(path=conftest.idb_path, args=opts, save_on_close=False)
+    try:
+        assert db.is_open()
+    finally:
+        db.close(False)
+    assert os.path.exists(log_file)
+
+
+def test_output_database_with_spaces():
+    """output_database paths with spaces must reach IDA as a single -o argument."""
+    output_database = os.path.join(os.path.dirname(conftest.idb_path), 'out db with spaces.i64')
+
+    opts = IdaCommandOptions(output_database=output_database)
+    db = ida_domain.Database.open(path=conftest.idb_path, args=opts, save_on_close=False)
+    try:
+        assert db.is_open()
+    finally:
+        db.close(True)
+    assert os.path.exists(output_database)
+
+
+def test_windows_dir_with_spaces():
+    """windows_dir paths with spaces must reach IDA as a single -W argument."""
+    opts = IdaCommandOptions(new_database=True, windows_dir='C:\\Program Files')
+    db = ida_domain.Database.open(path=conftest.idb_path, args=opts, save_on_close=False)
+    try:
+        assert db.is_open()
+    finally:
+        db.close(False)
+
+
+def test_script_file_with_spaces():
+    """script_file paths with spaces must reach IDA as a single -S argument."""
+    work_dir = os.path.dirname(conftest.idb_path)
+    script = os.path.join(work_dir, 'script with spaces.py')
+    marker = os.path.join(work_dir, 'script_marker.txt')
+    with open(script, 'w') as f:
+        f.write(f'open(r"{marker}", "w").write("ok")\n')
+
+    opts = IdaCommandOptions(new_database=True, script_file=script)
+    db = ida_domain.Database.open(path=conftest.idb_path, args=opts, save_on_close=False)
+    try:
+        assert db.is_open()
+    finally:
+        db.close(False)
+    assert os.path.exists(marker)
+
+
 def test_ida_command_options():
     # Test default state produces empty args
     opts = IdaCommandOptions()
@@ -159,7 +225,7 @@ def test_ida_command_options():
 
     # Test log file option
     opts = IdaCommandOptions(log_file='debug.log')
-    assert opts.build_args() == '-Ldebug.log'
+    assert opts.build_args() == '-L"debug.log"'
 
     # Test disable mouse option
     opts = IdaCommandOptions(disable_mouse=True)
@@ -171,7 +237,7 @@ def test_ida_command_options():
 
     # Test output database option (should also set -c flag)
     opts = IdaCommandOptions(output_database='output.idb')
-    assert opts.build_args() == '-c -ooutput.idb'
+    assert opts.build_args() == '-c -o"output.idb"'
 
     # Test processor option
     opts = IdaCommandOptions(processor='arm')
@@ -200,7 +266,7 @@ def test_ida_command_options():
 
     # Test run script option
     opts = IdaCommandOptions(script_file='analyze.py')
-    assert opts.build_args() == '-Sanalyze.py'
+    assert opts.build_args() == '-S"analyze.py"'
 
     args = ['arg1', 'arg with spaces', '--flag=value']
     opts = IdaCommandOptions(script_file='script.py', script_args=args)
@@ -208,10 +274,10 @@ def test_ida_command_options():
 
     # Test file type option
     opts = IdaCommandOptions(file_type='PE')
-    assert opts.build_args() == '-TPE'
+    assert opts.build_args() == '-T"PE"'
 
     opts = IdaCommandOptions(file_type='ZIP', file_member='classes.dex')
-    assert opts.build_args() == '-TZIP:classes.dex'
+    assert opts.build_args() == '-T"ZIP:classes.dex"'
 
     # Test empty database option
     opts = IdaCommandOptions(empty_database=True)
@@ -219,7 +285,7 @@ def test_ida_command_options():
 
     # Test Windows directory option
     opts = IdaCommandOptions(windows_dir='C:\\Windows')
-    assert opts.build_args() == '-WC:\\Windows'
+    assert opts.build_args() == '-W"C:\\Windows"'
 
     # Test no segmentation option
     opts = IdaCommandOptions(no_segmentation=True)
@@ -238,7 +304,7 @@ def test_ida_command_options():
     # Test combined options (no chaining, just set fields)
     opts = IdaCommandOptions(auto_analysis=False, log_file='analysis.log', processor='arm')
     args = opts.build_args()
-    assert args == '-a -Lanalysis.log -parm'
+    assert args == '-a -L"analysis.log" -parm'
 
     # Test complex scenario
     opts = IdaCommandOptions(
@@ -260,7 +326,7 @@ def test_ida_command_options():
         debug_flags=0x10004,  # debugger + flirt
     )
     args = opts.build_args()
-    assert args == '-c -oproject.idb -P+ -TZIP:classes.dex -z10004'
+    assert args == '-c -o"project.idb" -P+ -T"ZIP:classes.dex" -z10004'
 
     # Test default for auto_analysis is True
     opts = IdaCommandOptions()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -105,6 +105,7 @@ def test_database(test_env):
     db3.close(False)
 
 
+@conftest.min_ida_version('9.2')
 def test_file_type_with_spaces():
     """file_type values with spaces must reach IDA as a single -T argument."""
     opts = IdaCommandOptions(new_database=True, file_type='ELF64 for x86-64 (Relocatable)')

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,7 @@
 import os
 
 import conftest
+from conftest import min_ida_version
 
 import ida_domain  # isort: skip
 
@@ -105,7 +106,7 @@ def test_database(test_env):
     db3.close(False)
 
 
-@conftest.min_ida_version('9.2')
+@min_ida_version('9.2')
 def test_file_type_with_spaces():
     """file_type values with spaces must reach IDA as a single -T argument."""
     opts = IdaCommandOptions(new_database=True, file_type='ELF64 for x86-64 (Relocatable)')
@@ -143,6 +144,7 @@ def test_output_database_with_spaces():
     assert os.path.exists(output_database)
 
 
+@min_ida_version('9.2')
 def test_windows_dir_with_spaces():
     """windows_dir paths with spaces must reach IDA as a single -W argument."""
     opts = IdaCommandOptions(new_database=True, windows_dir='C:\\Program Files')


### PR DESCRIPTION
Path parameters might contain spaces. They need to be wrapped in quotes.