### PR TITLE
Downgrade test guards to 9.4

### DIFF
--- a/tests/test_pseudocode.py
+++ b/tests/test_pseudocode.py
@@ -1681,7 +1681,7 @@ def test_instruction_make_return(test_env):
     assert insn.return_details is not None
 
 
-@min_ida_version("9.5")
+@min_ida_version("9.4")
 def test_instruction_make_if(test_env):
     """make_if creates an IF instruction with condition and branches."""
     db = test_env
@@ -1696,7 +1696,7 @@ def test_instruction_make_if(test_env):
     assert insn.if_details.has_else
 
 
-@min_ida_version("9.5")
+@min_ida_version("9.4")
 def test_instruction_make_if_no_else(test_env):
     """make_if without else_branch creates IF without else."""
     db = test_env


### PR DESCRIPTION
These tests were fixed in IDA 9.4 Beta 2, so can be safely tested on 9.4 now