### PR TITLE
Fixed segment name and size printing for analyze_database example.

### DIFF
--- a/examples/analyze_database.py
+++ b/examples/analyze_database.py
@@ -63,10 +63,10 @@ def traverse_segments(db: ida_domain.Database) -> None:
 
     for i, segment in enumerate(segments, 1):
         print(
-            f'  [{i:2d}] {segment.name:20} | '
+            f'  [{i:2d}] {db.segments.get_name(segment):10} | '
             f'Start: 0x{segment.start_ea:08x} | '
             f'End: 0x{segment.end_ea:08x} | '
-            f'Size: {segment.size} | '
+            f'Size: 0x{db.segments.get_size(segment):08x} | '
             f'Type: {segment.type}'
         )
 


### PR DESCRIPTION
The current examples print some unreadable information about the database, for example segment names and size. This change more closely mirrors how the SDK says to retrieve names. 

**Testing**
I ran it on a database to validate output.

**Breaking Changes**
None.

**Related Issues**
Similar issues arise when printing function info, it's worth checking out for example code.
