### PR TITLE
Include examples in package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,34 @@ jobs:
       - name: Type checking
         run: uv run mypy ida_domain
 
+      - name: Build and verify package
+        run: |
+          rm -rf dist
+          uv build
+          uv run python - <<'PY'
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          expected = {
+              path.relative_to('examples').as_posix()
+              for path in Path('examples').rglob('*')
+              if path.is_file()
+          }
+          wheel = next(Path('dist').glob('*.whl'))
+          with ZipFile(wheel) as archive:
+              prefix = 'ida_domain/_examples/'
+              packaged = {
+                  name.removeprefix(prefix)
+                  for name in archive.namelist()
+                  if name.startswith(prefix) and not name.endswith('/')
+              }
+
+          assert packaged == expected, (
+              f'Packaged examples differ: missing={expected - packaged}, '
+              f'unexpected={packaged - expected}'
+          )
+          PY
+
       - name: Tests skipped notification
         if: env.HAS_IDA_CREDS != 'true'
         run: |

--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ Check the [`examples/`](https://github.com/HexRaysSA/ida-domain/tree/main/exampl
 uv run python examples/analyze_database.py
 ```
 
+Installed and editable packages can locate the examples programmatically:
+
+```python
+from ida_domain import examples_path
+
+examples = examples_path()
+```
+
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guidelines](https://github.com/HexRaysSA/ida-domain/blob/main/CONTRIBUTING.md) for details on how to:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -76,6 +76,14 @@ This example demonstrates a complete traversal of a database:
 
 ## Running the Examples
 
+Installed and editable packages can locate the examples programmatically:
+
+```python
+from ida_domain import examples_path
+
+examples = examples_path()
+```
+
 To run these examples, save them to Python files and execute them with your IDA database path:
 
 ```bash

--- a/ida_domain/__init__.py
+++ b/ida_domain/__init__.py
@@ -2,6 +2,27 @@ from __future__ import annotations
 
 import logging
 from logging import NullHandler
+from pathlib import Path
+
+
+def examples_path() -> Path:
+    """Return the directory containing the IDA Domain examples.
+
+    Packaged installations use the examples included in the distribution. Source
+    and editable installations fall back to the repository's ``examples`` directory.
+
+    Raises:
+        FileNotFoundError: If the examples are unavailable.
+    """
+    packaged_examples = Path(__file__).resolve().parent / '_examples'
+    if packaged_examples.is_dir():
+        return packaged_examples
+
+    checkout_examples = Path(__file__).resolve().parents[1] / 'examples'
+    if checkout_examples.is_dir():
+        return checkout_examples
+
+    raise FileNotFoundError('The IDA Domain examples could not be located')
 
 
 def _load_dependencies() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,14 @@ Repository = "https://github.com/hexrayssa/ida-domain"
 Issues = "https://github.com/hexrayssa/ida-domain/issues"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ida_domain"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"examples" = "ida_domain/_examples"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -48,6 +48,14 @@ def test_iterables(test_env):
     # check_iterations(types)
 
 
+def test_examples_path():
+    examples = ida_domain.examples_path()
+
+    assert examples.is_dir()
+    assert examples.joinpath('quick_example.py').is_file()
+    assert examples.joinpath('ida-python-equivalents', 'decompiler', 'vds1.py').is_file()
+
+
 def test_api_examples():
     """
     Make sure the examples are running fine


### PR DESCRIPTION
Another attempt at #79 

This works when installing editable as well as when packaging because hatchling follows the symbolic link when packaging.