### PR TITLE
Extend comments API

### DIFF
--- a/ida_domain/comments.py
+++ b/ida_domain/comments.py
@@ -128,29 +128,18 @@ class Comments(DatabaseEntity):
         Sets a comment at the specified address.
 
         Args:
-            ea: The effective address. Must not be a tail byte of a multi-byte
-                item.
+            ea: The effective address.
             comment: The comment text to assign.
             comment_kind: Type of comment to set (REGULAR or REPEATABLE).
 
         Raises:
             InvalidEAError: If the effective address is invalid.
-            InvalidParameterError: If ``ea`` is a tail byte or ``comment``
-                is not a string.
 
         Returns:
             True if the comment was successfully set, False otherwise.
-
-        Warning:
-            IDA caps regular and repeatable comments at 1024 bytes of UTF-8
-            and silently truncates longer text even though True is returned.
         """
         if not self.database.is_valid_ea(ea):
             raise InvalidEAError(ea)
-        if ida_bytes.is_tail(ida_bytes.get_flags(ea)):
-            raise InvalidParameterError('ea', ea, 'the address must not be an item tail byte')
-        if not isinstance(comment, str):
-            raise InvalidParameterError('comment', comment, 'the comment must be a string')
 
         comment_types = (
             [False, True]

--- a/ida_domain/comments.py
+++ b/ida_domain/comments.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from itertools import repeat
@@ -17,7 +18,13 @@ from ida_segment import segment_t
 from ida_typeinf import tinfo_t
 from typing_extensions import TYPE_CHECKING, Iterator, Optional
 
-from .base import DatabaseEntity, InvalidEAError, check_db_open, decorate_all_methods
+from .base import (
+    DatabaseEntity,
+    InvalidEAError,
+    InvalidParameterError,
+    check_db_open,
+    decorate_all_methods,
+)
 
 if TYPE_CHECKING:
     from .database import Database
@@ -42,6 +49,12 @@ class ExtraCommentKind(Enum):
 
     ANTERIOR = 'anterior'  # Comments before the line (E_PREV)
     POSTERIOR = 'posterior'  # Comments after the line (E_NEXT)
+
+
+_EXTRA_COMMENT_SLOT_COUNTS = {
+    ExtraCommentKind.ANTERIOR: ida_lines.E_NEXT - ida_lines.E_PREV - 1,
+    ExtraCommentKind.POSTERIOR: ida_lines.E_NEXT - ida_lines.E_PREV,
+}
 
 
 @dataclass(frozen=True)
@@ -115,18 +128,29 @@ class Comments(DatabaseEntity):
         Sets a comment at the specified address.
 
         Args:
-            ea: The effective address.
+            ea: The effective address. Must not be a tail byte of a multi-byte
+                item.
             comment: The comment text to assign.
             comment_kind: Type of comment to set (REGULAR or REPEATABLE).
 
         Raises:
             InvalidEAError: If the effective address is invalid.
+            InvalidParameterError: If ``ea`` is a tail byte or ``comment``
+                is not a string.
 
         Returns:
             True if the comment was successfully set, False otherwise.
+
+        Warning:
+            IDA caps regular and repeatable comments at 1024 bytes of UTF-8
+            and silently truncates longer text even though True is returned.
         """
         if not self.database.is_valid_ea(ea):
             raise InvalidEAError(ea)
+        if ida_bytes.is_tail(ida_bytes.get_flags(ea)):
+            raise InvalidParameterError('ea', ea, 'the address must not be an item tail byte')
+        if not isinstance(comment, str):
+            raise InvalidParameterError('comment', comment, 'the comment must be a string')
 
         comment_types = (
             [False, True]
@@ -159,6 +183,52 @@ class Comments(DatabaseEntity):
         )
         for is_repeatable in comment_types:
             ida_bytes.set_cmt(ea, '', is_repeatable)
+
+    def append_at(
+        self, ea: ea_t, comment: str, comment_kind: CommentKind = CommentKind.REGULAR
+    ) -> bool:
+        """
+        Appends text to a comment at the specified address.
+
+        If the selected comment does not exist, it is created with the given
+        text. Otherwise, a newline followed by the supplied text is appended.
+        Appending an empty string is a no-op and returns False.
+
+        Args:
+            ea: The effective address. Must not be a tail byte of a multi-byte
+                item.
+            comment: The comment text to append.
+            comment_kind: Type of comment to append to (REGULAR or REPEATABLE).
+
+        Raises:
+            InvalidEAError: If the effective address is invalid.
+            InvalidParameterError: If ``ea`` is a tail byte, ``comment``
+                is not a string, or ``comment_kind`` is ``ALL``.
+
+        Returns:
+            True if the comment was successfully appended, False otherwise.
+
+        Warning:
+            IDA caps regular and repeatable comments at 1024 bytes of UTF-8
+            and silently truncates longer text, so appending to a comment
+            near that limit drops the excess even though True is returned.
+        """
+        if not self.database.is_valid_ea(ea):
+            raise InvalidEAError(ea)
+        if ida_bytes.is_tail(ida_bytes.get_flags(ea)):
+            raise InvalidParameterError('ea', ea, 'the address must not be an item tail byte')
+        if comment_kind == CommentKind.ALL:
+            raise InvalidParameterError(
+                'comment_kind',
+                comment_kind,
+                'appending to both comment kinds at once is not supported',
+            )
+        if not isinstance(comment, str):
+            raise InvalidParameterError('comment', comment, 'the comment must be a string')
+        if not comment:
+            return False
+
+        return ida_bytes.append_cmt(ea, comment, comment_kind == CommentKind.REPEATABLE)
 
     def get_all(self, comment_kind: CommentKind = CommentKind.REGULAR) -> Iterator[CommentInfo]:
         """
@@ -216,6 +286,155 @@ class Comments(DatabaseEntity):
         base_idx = ida_lines.E_PREV if kind == ExtraCommentKind.ANTERIOR else ida_lines.E_NEXT
         return ida_lines.update_extra_cmt(ea, base_idx + index, comment)
 
+    def _set_extra_lines_at(self, ea: ea_t, lines: Iterable[str], kind: ExtraCommentKind) -> bool:
+        """Replace all extra comment lines of one kind."""
+        if not self.database.is_valid_ea(ea):
+            raise InvalidEAError(ea)
+        if isinstance(lines, str):
+            raise InvalidParameterError(
+                'lines', lines, 'must be an iterable of strings, not a single string'
+            )
+
+        materialized_lines: list[str] = []
+        for line in lines:
+            if not isinstance(line, str):
+                raise InvalidParameterError('lines', line, 'every comment line must be a string')
+            materialized_lines.extend(line.replace('\r\n', '\n').replace('\r', '\n').split('\n'))
+
+        slot_count = _EXTRA_COMMENT_SLOT_COUNTS[kind]
+        if len(materialized_lines) > slot_count:
+            raise InvalidParameterError(
+                'lines',
+                len(materialized_lines),
+                f'at most {slot_count} {kind.value} comment lines are supported '
+                f'(counted after splitting embedded line breaks)',
+            )
+
+        if not self._clear_extra_lines_at(ea, kind):
+            return False
+        for index, comment in enumerate(materialized_lines):
+            if not self.set_extra_at(ea, index, comment, kind):
+                return False
+        return True
+
+    def _clear_extra_lines_at(self, ea: ea_t, kind: ExtraCommentKind) -> bool:
+        """Delete all extra comment lines of one kind, including lines after gaps."""
+        if not self.database.is_valid_ea(ea):
+            raise InvalidEAError(ea)
+
+        base_idx = ida_lines.E_PREV if kind == ExtraCommentKind.ANTERIOR else ida_lines.E_NEXT
+        success = True
+        for index in range(base_idx, base_idx + _EXTRA_COMMENT_SLOT_COUNTS[kind]):
+            if ida_lines.get_extra_cmt(ea, index) is not None:
+                success = ida_lines.del_extra_cmt(ea, index) and success
+        return success
+
+    def set_anterior_lines_at(self, ea: ea_t, lines: Iterable[str]) -> bool:
+        """
+        Replaces all anterior comment lines at the specified address.
+
+        Passing an empty iterable clears all anterior comment lines. The input
+        iterable is consumed before the existing comments are changed. A line
+        containing line breaks is split into separate comment lines.
+
+        Args:
+            ea: The effective address.
+            lines: Comment lines in display order, at most 999.
+
+        Raises:
+            InvalidEAError: If the effective address is invalid.
+            InvalidParameterError: If ``lines`` is a single string instead of
+                an iterable of strings, contains a non-string element, or
+                exceeds the supported line count. The existing comment lines
+                are left unchanged in this case.
+
+        Returns:
+            True if the existing lines were cleared and every new line was
+            successfully set, False otherwise.
+
+        Note:
+            IDA does not provide a transactional bulk update. The existing
+            lines are cleared before the new ones are written, so if setting
+            a line fails, the original lines are already lost and only a
+            partial replacement remains stored.
+
+        Warning:
+            IDA caps each line at 1024 bytes of UTF-8 and silently truncates
+            longer lines even though True is returned.
+        """
+        return self._set_extra_lines_at(ea, lines, ExtraCommentKind.ANTERIOR)
+
+    def set_posterior_lines_at(self, ea: ea_t, lines: Iterable[str]) -> bool:
+        """
+        Replaces all posterior comment lines at the specified address.
+
+        Passing an empty iterable clears all posterior comment lines. The input
+        iterable is consumed before the existing comments are changed. A line
+        containing line breaks is split into separate comment lines.
+
+        Args:
+            ea: The effective address.
+            lines: Comment lines in display order, at most 1000.
+
+        Raises:
+            InvalidEAError: If the effective address is invalid.
+            InvalidParameterError: If ``lines`` is a single string instead of
+                an iterable of strings, contains a non-string element, or
+                exceeds the supported line count. The existing comment lines
+                are left unchanged in this case.
+
+        Returns:
+            True if the existing lines were cleared and every new line was
+            successfully set, False otherwise.
+
+        Note:
+            IDA does not provide a transactional bulk update. The existing
+            lines are cleared before the new ones are written, so if setting
+            a line fails, the original lines are already lost and only a
+            partial replacement remains stored.
+
+        Warning:
+            IDA caps each line at 1024 bytes of UTF-8 and silently truncates
+            longer lines even though True is returned.
+        """
+        return self._set_extra_lines_at(ea, lines, ExtraCommentKind.POSTERIOR)
+
+    def clear_anterior_at(self, ea: ea_t) -> bool:
+        """
+        Deletes all anterior comment lines at the specified address.
+
+        Args:
+            ea: The effective address.
+
+        Raises:
+            InvalidEAError: If the effective address is invalid.
+
+        Returns:
+            True if every line was successfully deleted, False otherwise.
+        """
+        if not self.database.is_valid_ea(ea):
+            raise InvalidEAError(ea)
+
+        return self._clear_extra_lines_at(ea, ExtraCommentKind.ANTERIOR)
+
+    def clear_posterior_at(self, ea: ea_t) -> bool:
+        """
+        Deletes all posterior comment lines at the specified address.
+
+        Args:
+            ea: The effective address.
+
+        Raises:
+            InvalidEAError: If the effective address is invalid.
+
+        Returns:
+            True if every line was successfully deleted, False otherwise.
+        """
+        if not self.database.is_valid_ea(ea):
+            raise InvalidEAError(ea)
+
+        return self._clear_extra_lines_at(ea, ExtraCommentKind.POSTERIOR)
+
     def get_extra_at(self, ea: int, index: int, kind: ExtraCommentKind) -> Optional[str]:
         """
         Gets a specific extra comment.
@@ -262,6 +481,59 @@ class Comments(DatabaseEntity):
                 break
             yield comment
             index += 1
+
+    def get_combined_at(
+        self,
+        ea: ea_t,
+        *,
+        include_regular: bool = True,
+        include_repeatable: bool = True,
+        include_anterior: bool = True,
+        include_posterior: bool = True,
+    ) -> Optional[str]:
+        """
+        Combines the selected comments at an address into one text block.
+
+        Lines are returned in logical listing order: anterior comments, the
+        regular comment, the repeatable comment, and posterior comments. This
+        method returns stored comment text only. Extra comment lines stored
+        after a missing index are omitted. On a tail byte, the regular and
+        repeatable comments are read from the item head.
+
+        Args:
+            ea: The effective address.
+            include_regular: Include the regular comment.
+            include_repeatable: Include the repeatable comment.
+            include_anterior: Include anterior comment lines.
+            include_posterior: Include posterior comment lines.
+
+        Raises:
+            InvalidEAError: If the effective address is invalid.
+
+        Returns:
+            The selected comments joined by newlines, or None if none exist.
+        """
+        if not self.database.is_valid_ea(ea):
+            raise InvalidEAError(ea)
+
+        comments: list[str] = []
+        if include_anterior:
+            comments.extend(self.get_all_extra_at(ea, ExtraCommentKind.ANTERIOR))
+
+        if include_regular:
+            regular = self.get_at(ea, CommentKind.REGULAR)
+            if regular is not None:
+                comments.append(regular.comment)
+
+        if include_repeatable:
+            repeatable_comment = self.get_at(ea, CommentKind.REPEATABLE)
+            if repeatable_comment is not None:
+                comments.append(repeatable_comment.comment)
+
+        if include_posterior:
+            comments.extend(self.get_all_extra_at(ea, ExtraCommentKind.POSTERIOR))
+
+        return '\n'.join(comments) if comments else None
 
     def delete_extra_at(self, ea: int, index: int, kind: ExtraCommentKind) -> bool:
         """

--- a/ida_domain/comments.py
+++ b/ida_domain/comments.py
@@ -181,7 +181,8 @@ class Comments(DatabaseEntity):
 
         If the selected comment does not exist, it is created with the given
         text. Otherwise, a newline followed by the supplied text is appended.
-        Appending an empty string is a no-op and returns False.
+        This method always works on the item comment. Function comments are
+        managed by the functions API.
 
         Args:
             ea: The effective address. Must not be a tail byte of a multi-byte
@@ -191,8 +192,8 @@ class Comments(DatabaseEntity):
 
         Raises:
             InvalidEAError: If the effective address is invalid.
-            InvalidParameterError: If ``ea`` is a tail byte, ``comment``
-                is not a string, or ``comment_kind`` is ``ALL``.
+            InvalidParameterError: If ``ea`` is a tail byte or ``comment_kind``
+                is ``ALL``.
 
         Returns:
             True if the comment was successfully appended, False otherwise.
@@ -204,7 +205,7 @@ class Comments(DatabaseEntity):
         """
         if not self.database.is_valid_ea(ea):
             raise InvalidEAError(ea)
-        if ida_bytes.is_tail(ida_bytes.get_flags(ea)):
+        if self.database.bytes.is_tail_at(ea):
             raise InvalidParameterError('ea', ea, 'the address must not be an item tail byte')
         if comment_kind == CommentKind.ALL:
             raise InvalidParameterError(
@@ -212,12 +213,10 @@ class Comments(DatabaseEntity):
                 comment_kind,
                 'appending to both comment kinds at once is not supported',
             )
-        if not isinstance(comment, str):
-            raise InvalidParameterError('comment', comment, 'the comment must be a string')
-        if not comment:
-            return False
-
-        return ida_bytes.append_cmt(ea, comment, comment_kind == CommentKind.REPEATABLE)
+        is_repeatable = comment_kind == CommentKind.REPEATABLE
+        existing = ida_bytes.get_cmt(ea, is_repeatable)
+        combined = f'{existing}\n{comment}' if existing else comment
+        return ida_bytes.set_cmt(ea, combined, is_repeatable)
 
     def get_all(self, comment_kind: CommentKind = CommentKind.REGULAR) -> Iterator[CommentInfo]:
         """
@@ -275,8 +274,41 @@ class Comments(DatabaseEntity):
         base_idx = ida_lines.E_PREV if kind == ExtraCommentKind.ANTERIOR else ida_lines.E_NEXT
         return ida_lines.update_extra_cmt(ea, base_idx + index, comment)
 
-    def _set_extra_lines_at(self, ea: ea_t, lines: Iterable[str], kind: ExtraCommentKind) -> bool:
-        """Replace all extra comment lines of one kind."""
+    def set_extra_lines_at(self, ea: ea_t, lines: Iterable[str], kind: ExtraCommentKind) -> bool:
+        """
+        Replaces all extra comment lines of one kind at the specified address.
+
+        Passing an empty iterable deletes all lines of that kind. The input
+        iterable is consumed before the existing comments are changed. A line
+        containing line breaks is split into separate comment lines.
+
+        Args:
+            ea: The effective address.
+            lines: Comment lines in display order, at most 999 for ANTERIOR
+                and 1000 for POSTERIOR.
+            kind: ANTERIOR or POSTERIOR.
+
+        Raises:
+            InvalidEAError: If the effective address is invalid.
+            InvalidParameterError: If ``lines`` is a single string instead of
+                an iterable of strings, contains a non-string element, or
+                exceeds the supported line count. The existing comment lines
+                are left unchanged in this case.
+
+        Returns:
+            True if the existing lines were deleted and every new line was
+            successfully set, False otherwise.
+
+        Note:
+            IDA does not provide a transactional bulk update. The existing
+            lines are deleted before the new ones are written, so if setting
+            a line fails, the original lines are already lost and only a
+            partial replacement remains stored.
+
+        Warning:
+            IDA caps each line at 1024 bytes of UTF-8 and silently truncates
+            longer lines even though True is returned.
+        """
         if not self.database.is_valid_ea(ea):
             raise InvalidEAError(ea)
         if isinstance(lines, str):
@@ -299,15 +331,30 @@ class Comments(DatabaseEntity):
                 f'(counted after splitting embedded line breaks)',
             )
 
-        if not self._clear_extra_lines_at(ea, kind):
+        if not self.delete_extra_lines_at(ea, kind):
             return False
         for index, comment in enumerate(materialized_lines):
             if not self.set_extra_at(ea, index, comment, kind):
                 return False
         return True
 
-    def _clear_extra_lines_at(self, ea: ea_t, kind: ExtraCommentKind) -> bool:
-        """Delete all extra comment lines of one kind, including lines after gaps."""
+    def delete_extra_lines_at(self, ea: ea_t, kind: ExtraCommentKind) -> bool:
+        """
+        Deletes all extra comment lines of one kind at the specified address.
+
+        Lines stored after a gap, which are invisible in the listing, are
+        deleted as well.
+
+        Args:
+            ea: The effective address.
+            kind: ANTERIOR or POSTERIOR.
+
+        Raises:
+            InvalidEAError: If the effective address is invalid.
+
+        Returns:
+            True if every line was successfully deleted, False otherwise.
+        """
         if not self.database.is_valid_ea(ea):
             raise InvalidEAError(ea)
 
@@ -317,112 +364,6 @@ class Comments(DatabaseEntity):
             if ida_lines.get_extra_cmt(ea, index) is not None:
                 success = ida_lines.del_extra_cmt(ea, index) and success
         return success
-
-    def set_anterior_lines_at(self, ea: ea_t, lines: Iterable[str]) -> bool:
-        """
-        Replaces all anterior comment lines at the specified address.
-
-        Passing an empty iterable clears all anterior comment lines. The input
-        iterable is consumed before the existing comments are changed. A line
-        containing line breaks is split into separate comment lines.
-
-        Args:
-            ea: The effective address.
-            lines: Comment lines in display order, at most 999.
-
-        Raises:
-            InvalidEAError: If the effective address is invalid.
-            InvalidParameterError: If ``lines`` is a single string instead of
-                an iterable of strings, contains a non-string element, or
-                exceeds the supported line count. The existing comment lines
-                are left unchanged in this case.
-
-        Returns:
-            True if the existing lines were cleared and every new line was
-            successfully set, False otherwise.
-
-        Note:
-            IDA does not provide a transactional bulk update. The existing
-            lines are cleared before the new ones are written, so if setting
-            a line fails, the original lines are already lost and only a
-            partial replacement remains stored.
-
-        Warning:
-            IDA caps each line at 1024 bytes of UTF-8 and silently truncates
-            longer lines even though True is returned.
-        """
-        return self._set_extra_lines_at(ea, lines, ExtraCommentKind.ANTERIOR)
-
-    def set_posterior_lines_at(self, ea: ea_t, lines: Iterable[str]) -> bool:
-        """
-        Replaces all posterior comment lines at the specified address.
-
-        Passing an empty iterable clears all posterior comment lines. The input
-        iterable is consumed before the existing comments are changed. A line
-        containing line breaks is split into separate comment lines.
-
-        Args:
-            ea: The effective address.
-            lines: Comment lines in display order, at most 1000.
-
-        Raises:
-            InvalidEAError: If the effective address is invalid.
-            InvalidParameterError: If ``lines`` is a single string instead of
-                an iterable of strings, contains a non-string element, or
-                exceeds the supported line count. The existing comment lines
-                are left unchanged in this case.
-
-        Returns:
-            True if the existing lines were cleared and every new line was
-            successfully set, False otherwise.
-
-        Note:
-            IDA does not provide a transactional bulk update. The existing
-            lines are cleared before the new ones are written, so if setting
-            a line fails, the original lines are already lost and only a
-            partial replacement remains stored.
-
-        Warning:
-            IDA caps each line at 1024 bytes of UTF-8 and silently truncates
-            longer lines even though True is returned.
-        """
-        return self._set_extra_lines_at(ea, lines, ExtraCommentKind.POSTERIOR)
-
-    def clear_anterior_at(self, ea: ea_t) -> bool:
-        """
-        Deletes all anterior comment lines at the specified address.
-
-        Args:
-            ea: The effective address.
-
-        Raises:
-            InvalidEAError: If the effective address is invalid.
-
-        Returns:
-            True if every line was successfully deleted, False otherwise.
-        """
-        if not self.database.is_valid_ea(ea):
-            raise InvalidEAError(ea)
-
-        return self._clear_extra_lines_at(ea, ExtraCommentKind.ANTERIOR)
-
-    def clear_posterior_at(self, ea: ea_t) -> bool:
-        """
-        Deletes all posterior comment lines at the specified address.
-
-        Args:
-            ea: The effective address.
-
-        Raises:
-            InvalidEAError: If the effective address is invalid.
-
-        Returns:
-            True if every line was successfully deleted, False otherwise.
-        """
-        if not self.database.is_valid_ea(ea):
-            raise InvalidEAError(ea)
-
-        return self._clear_extra_lines_at(ea, ExtraCommentKind.POSTERIOR)
 
     def get_extra_at(self, ea: int, index: int, kind: ExtraCommentKind) -> Optional[str]:
         """
@@ -483,11 +424,12 @@ class Comments(DatabaseEntity):
         """
         Combines the selected comments at an address into one text block.
 
-        Lines are returned in logical listing order: anterior comments, the
-        regular comment, the repeatable comment, and posterior comments. This
-        method returns stored comment text only. Extra comment lines stored
-        after a missing index are omitted. On a tail byte, the regular and
-        repeatable comments are read from the item head.
+        Lines are returned in listing order: anterior comments, the regular
+        or repeatable comment, and posterior comments. Matching the listing
+        behavior, the repeatable comment is used only when no regular comment
+        is included. Extra comment lines stored after a missing index are
+        omitted. On a tail byte, the regular and repeatable comments are read
+        from the item head.
 
         Args:
             ea: The effective address.
@@ -509,15 +451,11 @@ class Comments(DatabaseEntity):
         if include_anterior:
             comments.extend(self.get_all_extra_at(ea, ExtraCommentKind.ANTERIOR))
 
-        if include_regular:
-            regular = self.get_at(ea, CommentKind.REGULAR)
-            if regular is not None:
-                comments.append(regular.comment)
-
-        if include_repeatable:
-            repeatable_comment = self.get_at(ea, CommentKind.REPEATABLE)
-            if repeatable_comment is not None:
-                comments.append(repeatable_comment.comment)
+        displayed = self.get_at(ea, CommentKind.REGULAR) if include_regular else None
+        if displayed is None and include_repeatable:
+            displayed = self.get_at(ea, CommentKind.REPEATABLE)
+        if displayed is not None:
+            comments.append(displayed.comment)
 
         if include_posterior:
             comments.extend(self.get_all_extra_at(ea, ExtraCommentKind.POSTERIOR))

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -134,7 +134,6 @@ def test_comments(test_env):
 
 HEAD_EA = 0xAE  # Instruction head with no pre-existing comments
 TAIL_EA = 0x100  # Tail byte of the 8-byte instruction at 0xFF
-UNEXPLORED_EA = 0x338
 INVALID_EA = 0xFFFFFFFF
 EXTRA_LINE_APIS = [
     pytest.param(
@@ -156,19 +155,6 @@ EXTRA_LINE_APIS = [
 
 def _extra_lines(db, kind, ea=HEAD_EA):
     return list(db.comments.get_all_extra_at(ea, kind))
-
-
-def test_set_at_validation(test_env):
-    db = test_env
-
-    with pytest.raises(ida_domain.base.InvalidParameterError):
-        db.comments.set_at(TAIL_EA, 'Tail comment')
-    with pytest.raises(ida_domain.base.InvalidParameterError):
-        db.comments.set_at(HEAD_EA, 42)
-
-    # Unexplored bytes are not tail bytes, so comments are allowed there.
-    assert db.comments.set_at(UNEXPLORED_EA, 'Unexplored comment')
-    assert db.comments.get_at(UNEXPLORED_EA).comment == 'Unexplored comment'
 
 
 def test_append_at(test_env):

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,3 +1,4 @@
+import ida_lines
 import pytest
 
 import ida_domain  # isort: skip
@@ -134,22 +135,11 @@ def test_comments(test_env):
 
 HEAD_EA = 0xAE  # Instruction head with no pre-existing comments
 TAIL_EA = 0x100  # Tail byte of the 8-byte instruction at 0xFF
+FUNC_EA = 0xC4  # Function start address
 INVALID_EA = 0xFFFFFFFF
-EXTRA_LINE_APIS = [
-    pytest.param(
-        'set_anterior_lines_at',
-        'clear_anterior_at',
-        ida_domain.comments.ExtraCommentKind.ANTERIOR,
-        999,
-        id='anterior',
-    ),
-    pytest.param(
-        'set_posterior_lines_at',
-        'clear_posterior_at',
-        ida_domain.comments.ExtraCommentKind.POSTERIOR,
-        1000,
-        id='posterior',
-    ),
+EXTRA_LINE_KINDS = [
+    pytest.param(ida_domain.comments.ExtraCommentKind.ANTERIOR, 999, id='anterior'),
+    pytest.param(ida_domain.comments.ExtraCommentKind.POSTERIOR, 1000, id='posterior'),
 ]
 
 
@@ -181,49 +171,81 @@ def test_append_at_validation(test_env):
     with pytest.raises(ida_domain.base.InvalidParameterError):
         db.comments.append_at(HEAD_EA, 'Both', ida_domain.comments.CommentKind.ALL)
     with pytest.raises(ida_domain.base.InvalidParameterError):
-        db.comments.append_at(HEAD_EA, 42)
-    with pytest.raises(ida_domain.base.InvalidParameterError):
         db.comments.append_at(TAIL_EA, 'Tail comment')
     with pytest.raises(ida_domain.base.InvalidEAError):
         db.comments.append_at(INVALID_EA, 'Invalid')
 
-    # Appending an empty string is a no-op and returns False.
-    assert not db.comments.append_at(HEAD_EA, '')
-
     assert db.comments.get_at(HEAD_EA).comment == 'Existing'
 
 
-@pytest.mark.parametrize('set_name,clear_name,kind,max_lines', EXTRA_LINE_APIS)
-def test_set_extra_lines_at(test_env, set_name, clear_name, kind, max_lines):
+def test_comments_are_rendered(test_env):
     db = test_env
-    set_lines = getattr(db.comments, set_name)
 
-    assert set_lines(HEAD_EA, (line for line in ['Line A', 'Line B', 'Line C']))
+    assert db.comments.append_at(HEAD_EA, 'Regular comment')
+    assert 'Regular comment' in db.bytes.get_disassembly_at(HEAD_EA)
+
+    db.comments.delete_at(HEAD_EA)
+    assert db.comments.set_at(
+        HEAD_EA, 'Repeatable comment', ida_domain.comments.CommentKind.REPEATABLE
+    )
+    assert 'Repeatable comment' in db.bytes.get_disassembly_at(HEAD_EA)
+
+    assert db.comments.set_extra_lines_at(
+        HEAD_EA, ['Anterior line'], ida_domain.comments.ExtraCommentKind.ANTERIOR
+    )
+    assert db.comments.set_extra_lines_at(
+        HEAD_EA, ['Posterior line'], ida_domain.comments.ExtraCommentKind.POSTERIOR
+    )
+    _, lines = ida_lines.generate_disassembly(HEAD_EA, 10, False, False)
+    rendered = [ida_lines.tag_remove(line) for line in lines]
+    assert any('Anterior line' in line for line in rendered)
+    assert any('Posterior line' in line for line in rendered)
+
+
+def test_append_at_function_start(test_env):
+    db = test_env
+    func = db.functions.get_at(FUNC_EA)
+    assert func is not None and func.start_ea == FUNC_EA
+    assert db.functions.set_comment(func, 'Function comment')
+
+    # append_at works on the item comment and leaves the function comment alone.
+    assert db.comments.append_at(FUNC_EA, 'Item first')
+    assert db.comments.append_at(FUNC_EA, 'Item second')
+    assert db.comments.get_at(FUNC_EA).comment == 'Item first\nItem second'
+    assert db.functions.get_comment(func) == 'Function comment'
+
+
+@pytest.mark.parametrize('kind,max_lines', EXTRA_LINE_KINDS)
+def test_set_extra_lines_at(test_env, kind, max_lines):
+    db = test_env
+
+    assert db.comments.set_extra_lines_at(
+        HEAD_EA, (line for line in ['Line A', 'Line B', 'Line C']), kind
+    )
     assert _extra_lines(db, kind) == ['Line A', 'Line B', 'Line C']
 
     # Replacement removes all previous lines, not just the overwritten ones.
-    assert set_lines(HEAD_EA, ['Replacement'])
+    assert db.comments.set_extra_lines_at(HEAD_EA, ['Replacement'], kind)
     assert _extra_lines(db, kind) == ['Replacement']
     assert db.comments.get_extra_at(HEAD_EA, 1, kind) is None
 
-    assert set_lines(HEAD_EA, [])
+    assert db.comments.set_extra_lines_at(HEAD_EA, [], kind)
     assert _extra_lines(db, kind) == []
 
 
-@pytest.mark.parametrize('set_name,clear_name,kind,max_lines', EXTRA_LINE_APIS)
-def test_set_extra_lines_at_validation(test_env, set_name, clear_name, kind, max_lines):
+@pytest.mark.parametrize('kind,max_lines', EXTRA_LINE_KINDS)
+def test_set_extra_lines_at_validation(test_env, kind, max_lines):
     db = test_env
-    set_lines = getattr(db.comments, set_name)
-    assert set_lines(HEAD_EA, ['Existing line'])
+    assert db.comments.set_extra_lines_at(HEAD_EA, ['Existing line'], kind)
 
     with pytest.raises(ida_domain.base.InvalidParameterError):
-        set_lines(HEAD_EA, ['New line', 42])
+        db.comments.set_extra_lines_at(HEAD_EA, ['New line', 42], kind)
     with pytest.raises(ida_domain.base.InvalidParameterError):
-        set_lines(HEAD_EA, 'abc')
+        db.comments.set_extra_lines_at(HEAD_EA, 'abc', kind)
     with pytest.raises(ida_domain.base.InvalidParameterError):
-        set_lines(HEAD_EA, ['line'] * (max_lines + 1))
+        db.comments.set_extra_lines_at(HEAD_EA, ['line'] * (max_lines + 1), kind)
     with pytest.raises(ida_domain.base.InvalidEAError):
-        set_lines(INVALID_EA, [])
+        db.comments.set_extra_lines_at(INVALID_EA, [], kind)
 
     # Rejected calls must not touch the existing lines.
     assert _extra_lines(db, kind) == ['Existing line']
@@ -234,34 +256,32 @@ def test_set_extra_lines_at_splits_line_breaks(test_env):
     anterior = ida_domain.comments.ExtraCommentKind.ANTERIOR
 
     # Embedded line breaks split into separate lines; empty lines are preserved.
-    assert db.comments.set_anterior_lines_at(
-        HEAD_EA, ['Split 1\nSplit 2', '', 'Split 3\r\nSplit 4']
+    assert db.comments.set_extra_lines_at(
+        HEAD_EA, ['Split 1\nSplit 2', '', 'Split 3\r\nSplit 4'], anterior
     )
     expected = ['Split 1', 'Split 2', '', 'Split 3', 'Split 4']
     assert _extra_lines(db, anterior) == expected
 
     # The slot capacity applies to the line count after splitting.
     with pytest.raises(ida_domain.base.InvalidParameterError):
-        db.comments.set_anterior_lines_at(HEAD_EA, ['x\ny'] * 500)
+        db.comments.set_extra_lines_at(HEAD_EA, ['x\ny'] * 500, anterior)
     assert _extra_lines(db, anterior) == expected
 
 
-@pytest.mark.parametrize('set_name,clear_name,kind,max_lines', EXTRA_LINE_APIS)
-def test_clear_extra_lines_at(test_env, set_name, clear_name, kind, max_lines):
+@pytest.mark.parametrize('kind,max_lines', EXTRA_LINE_KINDS)
+def test_delete_extra_lines_at(test_env, kind, max_lines):
     db = test_env
-    set_lines = getattr(db.comments, set_name)
-    clear_lines = getattr(db.comments, clear_name)
 
-    assert set_lines(HEAD_EA, ['Visible line'])
-    # A line stored after a gap is invisible to get_all_extra_at but must be cleared too.
+    assert db.comments.set_extra_lines_at(HEAD_EA, ['Visible line'], kind)
+    # A line stored after a gap is invisible to get_all_extra_at but must be deleted too.
     assert db.comments.set_extra_at(HEAD_EA, 3, 'Hidden line', kind)
 
-    assert clear_lines(HEAD_EA)
+    assert db.comments.delete_extra_lines_at(HEAD_EA, kind)
     assert _extra_lines(db, kind) == []
     assert db.comments.get_extra_at(HEAD_EA, 3, kind) is None
 
     with pytest.raises(ida_domain.base.InvalidEAError):
-        clear_lines(INVALID_EA)
+        db.comments.delete_extra_lines_at(INVALID_EA, kind)
 
 
 def test_get_combined_at(test_env):
@@ -271,19 +291,32 @@ def test_get_combined_at(test_env):
 
     assert db.comments.set_at(HEAD_EA, 'Regular')
     assert db.comments.set_at(HEAD_EA, 'Repeatable', ida_domain.comments.CommentKind.REPEATABLE)
-    assert db.comments.set_anterior_lines_at(HEAD_EA, ['Anterior 1', 'Anterior 2'])
-    assert db.comments.set_posterior_lines_at(HEAD_EA, ['Posterior 1'])
-
-    # Listing order: anterior, regular, repeatable, posterior.
-    assert db.comments.get_combined_at(HEAD_EA) == (
-        'Anterior 1\nAnterior 2\nRegular\nRepeatable\nPosterior 1'
+    assert db.comments.set_extra_lines_at(
+        HEAD_EA, ['Anterior 1', 'Anterior 2'], ida_domain.comments.ExtraCommentKind.ANTERIOR
     )
+    assert db.comments.set_extra_lines_at(
+        HEAD_EA, ['Posterior 1'], ida_domain.comments.ExtraCommentKind.POSTERIOR
+    )
+
+    # Listing order: anterior, regular or repeatable, posterior.
+    assert db.comments.get_combined_at(HEAD_EA) == ('Anterior 1\nAnterior 2\nRegular\nPosterior 1')
 
     assert (
         db.comments.get_combined_at(
             HEAD_EA, include_repeatable=False, include_anterior=False, include_posterior=False
         )
         == 'Regular'
+    )
+    assert (
+        db.comments.get_combined_at(
+            HEAD_EA, include_regular=False, include_anterior=False, include_posterior=False
+        )
+        == 'Repeatable'
+    )
+
+    db.comments.delete_at(HEAD_EA)
+    assert db.comments.get_combined_at(HEAD_EA) == (
+        'Anterior 1\nAnterior 2\nRepeatable\nPosterior 1'
     )
     assert (
         db.comments.get_combined_at(
@@ -299,13 +332,13 @@ def test_get_combined_at(test_env):
     with pytest.raises(ida_domain.base.InvalidEAError):
         db.comments.get_combined_at(INVALID_EA)
     with pytest.raises(ida_domain.base.InvalidEAError):
-        db.comments.set_anterior_lines_at(0xFFFFFFFF, [])
+        db.comments.set_extra_lines_at(
+            0xFFFFFFFF, [], ida_domain.comments.ExtraCommentKind.ANTERIOR
+        )
     with pytest.raises(ida_domain.base.InvalidEAError):
-        db.comments.set_posterior_lines_at(0xFFFFFFFF, [])
-    with pytest.raises(ida_domain.base.InvalidEAError):
-        db.comments.clear_anterior_at(0xFFFFFFFF)
-    with pytest.raises(ida_domain.base.InvalidEAError):
-        db.comments.clear_posterior_at(0xFFFFFFFF)
+        db.comments.delete_extra_lines_at(
+            0xFFFFFFFF, ida_domain.comments.ExtraCommentKind.POSTERIOR
+        )
     with pytest.raises(ida_domain.base.InvalidEAError):
         db.comments.append_at(0xFFFFFFFF, 'Invalid')
     with pytest.raises(ida_domain.base.InvalidEAError):

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -130,3 +130,197 @@ def test_comments(test_env):
         )
     with pytest.raises(ida_domain.base.InvalidEAError):
         db.comments.delete_extra_at(0xFFFFFFFF, 0, ida_domain.comments.ExtraCommentKind.ANTERIOR)
+
+
+HEAD_EA = 0xAE  # Instruction head with no pre-existing comments
+TAIL_EA = 0x100  # Tail byte of the 8-byte instruction at 0xFF
+UNEXPLORED_EA = 0x338
+INVALID_EA = 0xFFFFFFFF
+EXTRA_LINE_APIS = [
+    pytest.param(
+        'set_anterior_lines_at',
+        'clear_anterior_at',
+        ida_domain.comments.ExtraCommentKind.ANTERIOR,
+        999,
+        id='anterior',
+    ),
+    pytest.param(
+        'set_posterior_lines_at',
+        'clear_posterior_at',
+        ida_domain.comments.ExtraCommentKind.POSTERIOR,
+        1000,
+        id='posterior',
+    ),
+]
+
+
+def _extra_lines(db, kind, ea=HEAD_EA):
+    return list(db.comments.get_all_extra_at(ea, kind))
+
+
+def test_set_at_validation(test_env):
+    db = test_env
+
+    with pytest.raises(ida_domain.base.InvalidParameterError):
+        db.comments.set_at(TAIL_EA, 'Tail comment')
+    with pytest.raises(ida_domain.base.InvalidParameterError):
+        db.comments.set_at(HEAD_EA, 42)
+
+    # Unexplored bytes are not tail bytes, so comments are allowed there.
+    assert db.comments.set_at(UNEXPLORED_EA, 'Unexplored comment')
+    assert db.comments.get_at(UNEXPLORED_EA).comment == 'Unexplored comment'
+
+
+def test_append_at(test_env):
+    db = test_env
+
+    assert db.comments.append_at(HEAD_EA, 'Regular first')
+    assert db.comments.append_at(HEAD_EA, 'Regular second')
+    assert db.comments.get_at(HEAD_EA).comment == 'Regular first\nRegular second'
+
+    assert db.comments.append_at(
+        HEAD_EA, 'Repeatable first', ida_domain.comments.CommentKind.REPEATABLE
+    )
+    assert (
+        db.comments.get_at(HEAD_EA, ida_domain.comments.CommentKind.REPEATABLE).comment
+        == 'Repeatable first'
+    )
+    assert db.comments.get_at(HEAD_EA).comment == 'Regular first\nRegular second'
+
+
+def test_append_at_validation(test_env):
+    db = test_env
+    assert db.comments.append_at(HEAD_EA, 'Existing')
+
+    with pytest.raises(ida_domain.base.InvalidParameterError):
+        db.comments.append_at(HEAD_EA, 'Both', ida_domain.comments.CommentKind.ALL)
+    with pytest.raises(ida_domain.base.InvalidParameterError):
+        db.comments.append_at(HEAD_EA, 42)
+    with pytest.raises(ida_domain.base.InvalidParameterError):
+        db.comments.append_at(TAIL_EA, 'Tail comment')
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        db.comments.append_at(INVALID_EA, 'Invalid')
+
+    # Appending an empty string is a no-op and returns False.
+    assert not db.comments.append_at(HEAD_EA, '')
+
+    assert db.comments.get_at(HEAD_EA).comment == 'Existing'
+
+
+@pytest.mark.parametrize('set_name,clear_name,kind,max_lines', EXTRA_LINE_APIS)
+def test_set_extra_lines_at(test_env, set_name, clear_name, kind, max_lines):
+    db = test_env
+    set_lines = getattr(db.comments, set_name)
+
+    assert set_lines(HEAD_EA, (line for line in ['Line A', 'Line B', 'Line C']))
+    assert _extra_lines(db, kind) == ['Line A', 'Line B', 'Line C']
+
+    # Replacement removes all previous lines, not just the overwritten ones.
+    assert set_lines(HEAD_EA, ['Replacement'])
+    assert _extra_lines(db, kind) == ['Replacement']
+    assert db.comments.get_extra_at(HEAD_EA, 1, kind) is None
+
+    assert set_lines(HEAD_EA, [])
+    assert _extra_lines(db, kind) == []
+
+
+@pytest.mark.parametrize('set_name,clear_name,kind,max_lines', EXTRA_LINE_APIS)
+def test_set_extra_lines_at_validation(test_env, set_name, clear_name, kind, max_lines):
+    db = test_env
+    set_lines = getattr(db.comments, set_name)
+    assert set_lines(HEAD_EA, ['Existing line'])
+
+    with pytest.raises(ida_domain.base.InvalidParameterError):
+        set_lines(HEAD_EA, ['New line', 42])
+    with pytest.raises(ida_domain.base.InvalidParameterError):
+        set_lines(HEAD_EA, 'abc')
+    with pytest.raises(ida_domain.base.InvalidParameterError):
+        set_lines(HEAD_EA, ['line'] * (max_lines + 1))
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        set_lines(INVALID_EA, [])
+
+    # Rejected calls must not touch the existing lines.
+    assert _extra_lines(db, kind) == ['Existing line']
+
+
+def test_set_extra_lines_at_splits_line_breaks(test_env):
+    db = test_env
+    anterior = ida_domain.comments.ExtraCommentKind.ANTERIOR
+
+    # Embedded line breaks split into separate lines; empty lines are preserved.
+    assert db.comments.set_anterior_lines_at(
+        HEAD_EA, ['Split 1\nSplit 2', '', 'Split 3\r\nSplit 4']
+    )
+    expected = ['Split 1', 'Split 2', '', 'Split 3', 'Split 4']
+    assert _extra_lines(db, anterior) == expected
+
+    # The slot capacity applies to the line count after splitting.
+    with pytest.raises(ida_domain.base.InvalidParameterError):
+        db.comments.set_anterior_lines_at(HEAD_EA, ['x\ny'] * 500)
+    assert _extra_lines(db, anterior) == expected
+
+
+@pytest.mark.parametrize('set_name,clear_name,kind,max_lines', EXTRA_LINE_APIS)
+def test_clear_extra_lines_at(test_env, set_name, clear_name, kind, max_lines):
+    db = test_env
+    set_lines = getattr(db.comments, set_name)
+    clear_lines = getattr(db.comments, clear_name)
+
+    assert set_lines(HEAD_EA, ['Visible line'])
+    # A line stored after a gap is invisible to get_all_extra_at but must be cleared too.
+    assert db.comments.set_extra_at(HEAD_EA, 3, 'Hidden line', kind)
+
+    assert clear_lines(HEAD_EA)
+    assert _extra_lines(db, kind) == []
+    assert db.comments.get_extra_at(HEAD_EA, 3, kind) is None
+
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        clear_lines(INVALID_EA)
+
+
+def test_get_combined_at(test_env):
+    db = test_env
+
+    assert db.comments.get_combined_at(HEAD_EA) is None
+
+    assert db.comments.set_at(HEAD_EA, 'Regular')
+    assert db.comments.set_at(HEAD_EA, 'Repeatable', ida_domain.comments.CommentKind.REPEATABLE)
+    assert db.comments.set_anterior_lines_at(HEAD_EA, ['Anterior 1', 'Anterior 2'])
+    assert db.comments.set_posterior_lines_at(HEAD_EA, ['Posterior 1'])
+
+    # Listing order: anterior, regular, repeatable, posterior.
+    assert db.comments.get_combined_at(HEAD_EA) == (
+        'Anterior 1\nAnterior 2\nRegular\nRepeatable\nPosterior 1'
+    )
+
+    assert (
+        db.comments.get_combined_at(
+            HEAD_EA, include_repeatable=False, include_anterior=False, include_posterior=False
+        )
+        == 'Regular'
+    )
+    assert (
+        db.comments.get_combined_at(
+            HEAD_EA,
+            include_regular=False,
+            include_repeatable=False,
+            include_anterior=False,
+            include_posterior=False,
+        )
+        is None
+    )
+
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        db.comments.get_combined_at(INVALID_EA)
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        db.comments.set_anterior_lines_at(0xFFFFFFFF, [])
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        db.comments.set_posterior_lines_at(0xFFFFFFFF, [])
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        db.comments.clear_anterior_at(0xFFFFFFFF)
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        db.comments.clear_posterior_at(0xFFFFFFFF)
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        db.comments.append_at(0xFFFFFFFF, 'Invalid')
+    with pytest.raises(ida_domain.base.InvalidEAError):
+        db.comments.get_combined_at(0xFFFFFFFF)


### PR DESCRIPTION
Added new APIs:

- `append_at(ea, comment, comment_kind=REGULAR)` - Appends text to a regular or repeatable comment on a new line, creating the comment if missing. Always works on the item comment (function comments are managed by the functions API).
- `set_extra_lines_at(ea, lines, kind)` - Replaces all anterior or posterior comment lines with the given iterable.
- `delete_extra_lines_at(ea, kind)` - Deletes all anterior or posterior comment lines, including lines hidden behind index gaps.
- `get_combined_at(ea, *, include_regular, include_repeatable, include_anterior, include_posterior)` - Returns the selected comments at an address joined into one newline-separated block, in listing order. Matching the listing behavior, the repeatable comment is included only when no regular comment is.